### PR TITLE
Cherry-pick #4

### DIFF
--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,1 +1,0 @@
-build/compile_commands.json

--- a/src/AttitudeObserver.cpp
+++ b/src/AttitudeObserver.cpp
@@ -151,7 +151,10 @@ bool AttitudeObserver::run(const mc_control::MCController & ctl)
 void AttitudeObserver::update(mc_control::MCController & ctl)
 {
   auto & sensor = ctl.robot(robot_).bodySensor(updateSensor_);
-  sensor.orientation(Eigen::Quaterniond{m_orientation.transpose()});
+  auto & realSensor = ctl.realRobot(robot_).bodySensor(updateSensor_);
+  Eigen::Quaterniond quat(m_orientation.transpose());
+  sensor.orientation(quat);
+  realSensor.orientation(quat);
 }
 
 void AttitudeObserver::addToLogger(const mc_control::MCController &,

--- a/src/SLAMObserver.cpp
+++ b/src/SLAMObserver.cpp
@@ -66,7 +66,7 @@ void SLAMObserver::configure(const mc_control::MCController & ctl, const mc_rtc:
   }
   else
   {
-    mc_rtc::log::error_and_throw<std::runtime_error>("[{}}] Robot configuration is mandatory.", name());
+    mc_rtc::log::error_and_throw<std::runtime_error>("[{}] Robot configuration is mandatory.", name());
   }
 
   if(config.has("SLAM"))


### PR DESCRIPTION
This PR brings in the commit in #4 by @mmurooka 

This fixes the Attitude observer usage in interfaces that do not set a sensor orientation. This strongly affects the stabilizer and this might cause or fix subtle issues with mc_openrtm/mc_udp and walking scenarios although I think this is unlikely as the "KalmanFilter" component and the Attitude observer are pretty similar nowadays