### PR TITLE
[SLAMObserver] Add configuration initializeWithIdentity

### DIFF
--- a/src/SLAMObserver.cpp
+++ b/src/SLAMObserver.cpp
@@ -82,6 +82,7 @@ void SLAMObserver::configure(const mc_control::MCController & ctl, const mc_rtc:
     {
       ground_ = static_cast<std::string>(config("SLAM")("ground"));
     }
+    config("SLAM")("initializeWithIdentity", isInitialized_);
   }
   else
   {


### PR DESCRIPTION
When you set `initializeWithIdentity` true, SLAM is automatically initialized with identity transformation between control origin and SLAM origin. This is useful if SLAM returns the absolute position correctly from the beginning (e.g., simulation).