### PR TITLE
Prepare for changes in mc_rtc

### DIFF
--- a/.clang-format-common.sh
+++ b/.clang-format-common.sh
@@ -1,8 +1,8 @@
 # This script is meant to be sourced from other scripts
 
 # Check for clang-format, prefer 6.0 if available
-if [[ -x "$(command -v clang-format-6.0)" ]]; then
-  clang_format=clang-format-6.0
+if [[ -x "$(command -v clang-format-10)" ]]; then
+  clang_format=clang-format-10
 elif [[ -x "$(command -v clang-format)" ]]; then
   clang_format=clang-format
 else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,13 @@ on:
 
 jobs:
   clang-format:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Install clang-format-6.0
+    - name: Install clang-format-10
       run: |
-        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get -qq update
-        sudo apt-get -qq remove clang-6.0 libclang1-6.0 libclang-common-6.0-dev libllvm6.0
-        sudo apt-get -qq install clang-format-6.0 clang-format
+        sudo apt-get -qq install clang-format-10
     - name: Run clang-format-check
       run: |
         ./.clang-format-check.sh
@@ -36,40 +34,25 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Temporary APT mirrors cleanup
-      if: startsWith(runner.os, 'Linux')
-      run: |
-        set -e
-        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
-    - name: Setup extra APT mirror
-      if: startsWith(runner.os, 'Linux')
-      run: |
-        set -x
-        set -e
-        curl -1sLf 'https://dl.cloudsmith.io/public/mc-rtc/head/setup.deb.sh' | sudo -E bash
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: Install dependencies
       uses: jrl-umi3218/github-actions/install-dependencies@master
       with:
         compiler: ${{ matrix.compiler }}
         build-type: ${{ matrix.build-type }}
         ubuntu: |
-          apt: libltdl-dev libboost-all-dev libmc-rtc-dev
+          apt: libltdl-dev libboost-all-dev doxgen doxygen-latex libmc-rtc-dev
+          apt-mirrors:
+            mc-rtc:
+              cloudsmith: mc-rtc/head
         macos: |
           brew-taps: mc-rtc/mc-rtc
           brew: boost mc_rtc
           github: # Get the head version of mc_rtc
             - path: jrl-umi3218/mc_rtc
               options: -DPYTHON_BINDING:BOOL=OFF
-    - uses: actions/checkout@v1
-      with:
-        submodules: recursive
-    - name: Install system dependencies
-      uses: jrl-umi3218/github-actions/install-dependencies@master
-      with:
-        compiler: ${{ matrix.compiler }}
-        build-type: ${{ matrix.build-type }}
-        ubuntu: |
-          apt: doxygen doxygen-latex libmc-rtc-dev
     - name: Build and test
       uses: jrl-umi3218/github-actions/build-cmake-project@master
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         compiler: ${{ matrix.compiler }}
         build-type: ${{ matrix.build-type }}
         ubuntu: |
-          apt: libltdl-dev libboost-all-dev doxgen doxygen-latex libmc-rtc-dev
+          apt: libltdl-dev libboost-all-dev doxygen doxygen-latex libmc-rtc-dev
           apt-mirrors:
             mc-rtc:
               cloudsmith: mc-rtc/head

--- a/include/mc_state_observation/ObjectObserver.h
+++ b/include/mc_state_observation/ObjectObserver.h
@@ -58,7 +58,7 @@ protected:
   /// @{
   std::string robot_ = ""; ///< Name of robot to estimate thanks to SLAM
   std::string camera_ = ""; ///< Name of robot's camera body
-  mc_rbdyn::Robots robots_; ///< Store robot estimated state if SLAM Observer is used
+  std::shared_ptr<mc_rbdyn::Robots> robots_; ///< Store robot estimated state if SLAM Observer is used
   /// @}
 
   /// @{

--- a/include/mc_state_observation/SLAMObserver.h
+++ b/include/mc_state_observation/SLAMObserver.h
@@ -53,7 +53,7 @@ protected:
   std::string robot_ = ""; ///< Name of robot to estimate thanks to SLAM
   std::string camera_ = ""; ///< Name of robot's camera body
   std::string body_ = ""; ///< Name of robot's freeflyer
-  mc_rbdyn::Robots robots_; ///< Store robot estimated state
+  std::shared_ptr<mc_rbdyn::Robots> robots_; ///< Store robot estimated state
   /// @}
 
   /// @{

--- a/src/MocapObserver.cpp
+++ b/src/MocapObserver.cpp
@@ -95,8 +95,9 @@ void MocapObserver::addToGUI(const mc_control::MCController & ctl,
                           mc_rtc::log::info("[{}] Manual reset triggerred", name());
                           reset(ctl);
                         }),
-                 Transform("Mocap Origin", [this]() -> const sva::PTransformd & { return X_0_mocap_; },
-                           [this](const sva::PTransformd & pose) { X_0_mocap_ = pose; }),
+                 Transform(
+                     "Mocap Origin", [this]() -> const sva::PTransformd & { return X_0_mocap_; },
+                     [this](const sva::PTransformd & pose) { X_0_mocap_ = pose; }),
                  Transform("Mocap Marker World", [this]() -> const sva::PTransformd & { return X_0_marker_; }),
                  Transform("Mocap Marker Frame", [this, &ctl]() -> const sva::PTransformd {
                    auto & realRobot = ctl.realRobot(updateRobot_);


### PR DESCRIPTION
In an upcoming PR for mc_rtc, `mc_rbdyn::Robots` cannot be created on the stack anymore, these changes prepare for this by using existing methods to load the `Robots` instance needed in some observers

@arntanguy this branch is miles ahead of the main branch, is there no mature observers here that could be incorporated to the main branch?