### PR TITLE
[ObjectObserver/bugfix] Load robot with the correct name

### DIFF
--- a/src/ObjectObserver.cpp
+++ b/src/ObjectObserver.cpp
@@ -40,7 +40,7 @@ void ObjectObserver::configure(const mc_control::MCController & controller, cons
     topic_ = static_cast<std::string>(config("Object")("topic"));
     isInRobotMap_ = config("Object")("inRobotMap", false);
 
-    robots_ = mc_rbdyn::loadRobot(ctl.robot(object_).module());
+    robots_ = mc_rbdyn::loadRobot(ctl.robot(object_).module(), object_);
   }
   else
   {


### PR DESCRIPTION
This PR fixes the loading of the additional object robot used in the `ObjectObserver`. #9 caused it to be loaded with the robot module's name instead of the desired object name as before (sorry I missed this).