### PR TITLE
[attitudeObserver] Add gyro-bias management

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools"
-}

--- a/include/mc_state_observation/AttitudeObserver.h
+++ b/include/mc_state_observation/AttitudeObserver.h
@@ -103,8 +103,8 @@ protected:
   stateObservation::Vector uk_;
   stateObservation::Vector xk_;
 
-  stateObservation::Matrix3 Kpt_, Kdt_;
-  stateObservation::Matrix3 Kpo_, Kdo_;
+  stateObservation::Matrix3 Kpt_, Kdt_, Kat_;
+  stateObservation::Matrix3 Kpo_, Kdo_, Kao_;
 
   Eigen::Matrix3d m_orientation = Eigen::Matrix3d::Identity(); ///< Result
   Eigen::Vector3d m_gyrobias = Eigen::Vector3d::Zero();

--- a/include/mc_state_observation/AttitudeObserver.h
+++ b/include/mc_state_observation/AttitudeObserver.h
@@ -11,9 +11,9 @@ namespace mc_state_observation
 struct AttitudeObserver : public mc_observers::Observer
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  using indexes = stateObservation::kine::indexes<stateObservation::kine::rotationVector>;
+  using indexes = stateObservation::IMUDynamicalSystem::indexes;
 
- public:
+public:
   AttitudeObserver(const std::string & type, double dt);
 
   void configure(const mc_control::MCController & ctl, const mc_rtc::Configuration &) override;

--- a/include/mc_state_observation/gui_helpers.h
+++ b/include/mc_state_observation/gui_helpers.h
@@ -35,6 +35,13 @@ auto make_number_input(std::string name, T & value)
   return NumberInputImpl<decltype(GetF), decltype(SetF)>(name, GetF, SetF);
 }
 
+auto make_xyz_input(std::string name, Eigen::Vector3d & vec)
+{
+  auto GetF = [&vec]() -> Eigen::Vector3d { return vec; };
+  auto SetF = [&vec](const Eigen::Vector3d & vecIn) { vec = vecIn; };
+  return ArrayInputImpl<decltype(GetF), decltype(SetF)>(name, {"x", "y", "z"}, GetF, SetF);
+}
+
 auto make_rpy_input(std::string name, Eigen::Matrix3d & orientation)
 {
   auto GetF = [&orientation]() -> Eigen::Vector3d

--- a/src/AttitudeObserver.cpp
+++ b/src/AttitudeObserver.cpp
@@ -71,7 +71,7 @@ void AttitudeObserver::reset(const mc_control::MCController & ctl)
 
   uk_.setZero();
 
-  filter_.setState(xk_, filter_.getCurrentTime());
+  filter_.setState(xk_, 0);
   filter_.setStateCovariance(so::Matrix::Identity(STATE_SIZE, STATE_SIZE) * c.stateInitCov);
 
   lastStateInitCovariance_ = c.stateInitCov;

--- a/src/AttitudeObserver.cpp
+++ b/src/AttitudeObserver.cpp
@@ -54,8 +54,8 @@ void AttitudeObserver::reset(const mc_control::MCController & ctl)
 
   q_.noalias() = so::Matrix::Identity(STATE_SIZE, STATE_SIZE) * c.stateCov;
   r_.noalias() = so::Matrix::Identity(MEASUREMENT_SIZE, MEASUREMENT_SIZE) * c.acceleroCovariance;
-  q_(9, 9) = q_(10, 10) = q_(11, 11) = c.orientationAccCov;
-  q_(6, 6) = q_(7, 7) = q_(8, 8) = c.linearAccCov;
+  q_.diagonal().segment<3>(indexes::angAcc).setConstant(c.orientationAccCov);
+  q_.diagonal().segment<3>(indexes::linAcc).setConstant(c.linearAccCov);
   r_(3, 3) = r_(4, 4) = r_(5, 5) = c.gyroCovariance;
 
   filter_.reset();

--- a/src/AttitudeObserver.cpp
+++ b/src/AttitudeObserver.cpp
@@ -7,25 +7,26 @@ namespace mc_state_observation
 {
 
 /// Sizes of the states for the state, the measurement, and the input vector
-constexpr unsigned AttitudeObserver::STATE_SIZE;
-constexpr unsigned AttitudeObserver::MEASUREMENT_SIZE;
-constexpr unsigned AttitudeObserver::INPUT_SIZE;
+constexpr stateObservation::Index AttitudeObserver::STATE_SIZE_BASE;
+constexpr stateObservation::Index AttitudeObserver::MEASUREMENT_SIZE;
+constexpr stateObservation::Index AttitudeObserver::INPUT_SIZE;
 
 namespace so = stateObservation;
 
 AttitudeObserver::AttitudeObserver(const std::string & type, double dt)
-: mc_observers::Observer(type, dt), filter_(STATE_SIZE, MEASUREMENT_SIZE, INPUT_SIZE, false),
-  q_(so::Matrix::Identity(STATE_SIZE, STATE_SIZE) * defaultConfig_.stateCov),
+: mc_observers::Observer(type, dt), filter_(STATE_SIZE_BASE, MEASUREMENT_SIZE, INPUT_SIZE, false),
+  q_(so::Matrix::Identity(STATE_SIZE_BASE, STATE_SIZE_BASE) * defaultConfig_.stateCov),
   r_(so::Matrix::Identity(MEASUREMENT_SIZE, MEASUREMENT_SIZE) * defaultConfig_.acceleroCovariance), uk_(INPUT_SIZE),
-  xk_(STATE_SIZE)
+  xk_(STATE_SIZE_BASE)
 {
   /// initialization of the extended Kalman filter
   imuFunctor_.setSamplingPeriod(dt_);
   filter_.setFunctor(&imuFunctor_);
+
   Kpt_ << -20, 0, 0, 0, -20, 0, 0, 0, -20;
   Kdt_ << -10, 0, 0, 0, -10, 0, 0, 0, -10;
-  Kpo_ << -0.0, 0, 0, 0, -0.0, 0, 0, 0, -10;
-  Kdo_ << -0.0, 0, 0, 0, -0.0, 0, 0, 0, -10;
+  Kpo_ << -0, 0, 0, 0, -0, 0, 0, 0, -20;
+  Kdo_ << -5, 0, 0, 0, -5, 0, 0, 0, -50;
 }
 
 void AttitudeObserver::configure(const mc_control::MCController & ctl, const mc_rtc::Configuration & config)
@@ -43,6 +44,12 @@ void AttitudeObserver::configure(const mc_control::MCController & ctl, const mc_
   datastoreName_ = config("datastoreName", name());
   config("log_kf", log_kf_);
   config("init_from_control", initFromControl_);
+  if(config.has("with_gyro_bias"))
+  {
+    config("with_gyro_bias", withGyroBias_);
+    imuFunctor_.setWithGyroBias(withGyroBias_);
+    stateSize_ = imuFunctor_.getStateSize();
+  }
   defaultConfig_ = config("KalmanFilter", KalmanFilterConfig{});
   config_ = defaultConfig_;
   desc_ = fmt::format("{} (sensor={})", name_, imuSensor_);
@@ -52,10 +59,15 @@ void AttitudeObserver::reset(const mc_control::MCController & ctl)
 {
   const auto & c = config_;
 
-  q_.noalias() = so::Matrix::Identity(STATE_SIZE, STATE_SIZE) * c.stateCov;
-  r_.noalias() = so::Matrix::Identity(MEASUREMENT_SIZE, MEASUREMENT_SIZE) * c.acceleroCovariance;
+  q_.noalias() = so::Matrix::Identity(stateSize_, stateSize_) * c.stateCov;
   q_.diagonal().segment<3>(indexes::angAcc).setConstant(c.orientationAccCov);
   q_.diagonal().segment<3>(indexes::linAcc).setConstant(c.linearAccCov);
+  if(withGyroBias_)
+  {
+    q_.diagonal().segment<3>(indexes::gyroBias).setConstant(c.biasDriftCov);
+  }
+
+  r_.noalias() = so::Matrix::Identity(MEASUREMENT_SIZE, MEASUREMENT_SIZE) * c.acceleroCovariance;
   r_(3, 3) = r_(4, 4) = r_(5, 5) = c.gyroCovariance;
 
   filter_.reset();
@@ -72,9 +84,22 @@ void AttitudeObserver::reset(const mc_control::MCController & ctl)
   uk_.setZero();
 
   filter_.setState(xk_, 0);
-  filter_.setStateCovariance(so::Matrix::Identity(STATE_SIZE, STATE_SIZE) * c.stateInitCov);
+
+  Eigen::MatrixXd P = filter_.getPmatrixZero();
+
+  P.diagonal().head<STATE_SIZE_BASE>().setConstant(c.stateInitCov);
+
+  if(withGyroBias_)
+  {
+    P.diagonal().segment<3>(indexes::gyroBias).setConstant(c.biasInitCov);
+  }
+
+  filter_.setStateCovariance(P);
 
   lastStateInitCovariance_ = c.stateInitCov;
+  m_gyrobias.setZero();
+  m_rateIn.setZero();
+  m_accIn.setZero();
 }
 
 bool AttitudeObserver::run(const mc_control::MCController & ctl)
@@ -82,10 +107,16 @@ bool AttitudeObserver::run(const mc_control::MCController & ctl)
   const auto & c = config_;
   bool ret = true;
 
-  q_.noalias() = so::Matrix::Identity(STATE_SIZE, STATE_SIZE) * c.stateCov;
+  q_.noalias() = so::Matrix::Identity(stateSize_, stateSize_) * c.stateCov;
+  q_.diagonal().segment<3>(indexes::angAcc).setConstant(c.orientationAccCov);
+  q_.diagonal().segment<3>(indexes::linAcc).setConstant(c.linearAccCov);
+  q_.diagonal().segment<3>(indexes::ori).setConstant(c.oriCov);
+  if(withGyroBias_)
+  {
+    q_.diagonal().segment<3>(12).setConstant(c.biasDriftCov);
+  }
+
   r_.noalias() = so::Matrix::Identity(MEASUREMENT_SIZE, MEASUREMENT_SIZE) * c.acceleroCovariance;
-  q_(9, 9) = q_(10, 10) = q_(11, 11) = c.orientationAccCov;
-  q_(6, 6) = q_(7, 7) = q_(8, 8) = c.linearAccCov;
   r_(3, 3) = r_(4, 4) = r_(5, 5) = c.gyroCovariance;
 
   filter_.setQ(q_);
@@ -93,14 +124,14 @@ bool AttitudeObserver::run(const mc_control::MCController & ctl)
 
   if(lastStateInitCovariance_ != c.stateInitCov) /// if the value of the state Init Covariance has changed
   {
-    filter_.setStateCovariance(so::Matrix::Identity(STATE_SIZE, STATE_SIZE) * c.stateInitCov);
+    filter_.setStateCovariance(so::Matrix::Identity(stateSize_, stateSize_) * c.stateInitCov);
     lastStateInitCovariance_ = c.stateInitCov;
   }
 
   // Get sensor values
   const mc_rbdyn::BodySensor & imu = ctl.robot(robot_).bodySensor(imuSensor_);
-  const Eigen::Vector3d & accIn = imu.linearAcceleration();
-  const Eigen::Vector3d & rateIn = imu.angularVelocity();
+  m_accIn = imu.linearAcceleration();
+  m_rateIn = imu.angularVelocity();
 
   // processing
   so::Vector6 measurement;
@@ -109,19 +140,27 @@ bool AttitudeObserver::run(const mc_control::MCController & ctl)
     if(ctl.datastore().has(datastoreName_ + "::accRef"))
     {
       const Eigen::Vector3d & accRef = ctl.datastore().get<Eigen::Vector3d>(datastoreName_ + "::accRef");
-      measurement.head<3>() = accIn - accRef;
+      measurement.head<3>() = m_accIn - accRef;
     }
     else
     {
-      measurement.head<3>() = accIn;
+      measurement.head<3>() = m_accIn;
       ret = false;
     }
   }
   else
   {
-    measurement.head<3>() = accIn;
+    measurement.head<3>() = m_accIn;
   }
-  measurement.tail<3>() = rateIn;
+
+  if(withGyroBias_) /// when the bias is estimated
+  {
+    measurement.tail<3>() = m_rateIn;
+  }
+  else
+  {
+    measurement.tail<3>() = m_rateIn - m_gyrobias;
+  }
 
   auto time = filter_.getCurrentTime();
 
@@ -129,11 +168,17 @@ bool AttitudeObserver::run(const mc_control::MCController & ctl)
   uk_.head<3>() = Kpt_ * xk_.segment<3>(indexes::pos) + Kdt_ * xk_.segment<3>(indexes::linVel);
   uk_.tail<3>() = Kpo_ * xk_.segment<3>(indexes::ori) + Kdo_ * xk_.segment<3>(indexes::angVel);
 
+  // uk_ is actually the acceleration change
+  uk_ -= xk_.segment<6>(indexes::linAcc);
+
   filter_.setInput(uk_, time);
   filter_.setMeasurement(measurement, time + 1);
 
   /// set the derivation step for the finite difference method
   const so::Vector dx = filter_.stateVectorConstant(1) * 1e-8;
+
+  Eigen::MatrixXd A = filter_.getAMatrixFD(dx);
+  Eigen::MatrixXd C = filter_.getCMatrixFD(dx);
 
   filter_.setA(filter_.getAMatrixFD(dx));
   filter_.setC(filter_.getCMatrixFD(dx));
@@ -144,6 +189,25 @@ bool AttitudeObserver::run(const mc_control::MCController & ctl)
   // result
   const so::Vector3 orientation(xk_.segment<3>(indexes::ori));
   m_orientation = c.offset * so::kine::rotationVectorToRotationMatrix(orientation);
+
+  if(withGyroBias_)
+  {
+    m_gyrobias = xk_.segment<3>(indexes::gyroBias);
+  }
+
+  if(m_gyroBiasFromMeasurement_running)
+  {
+    m_gyroMeasurementTotal += m_rateIn;
+    ++m_numberOfValues;
+  }
+
+  if(ctl.gui() && m_resetGUI)
+  {
+    removeFromGUI(*ctl.gui(), m_category);
+
+    addToGUI(ctl, *ctl.gui(), m_category);
+    m_resetGUI = false;
+  }
 
   return ret;
 }
@@ -183,6 +247,7 @@ void AttitudeObserver::addToGUI(const mc_control::MCController & ctl,
                                 mc_rtc::gui::StateBuilder & gui,
                                 const std::vector<std::string> & category)
 {
+  m_category = category;
   using namespace mc_rtc::gui;
   auto kf_category = category;
   kf_category.push_back("KalmanFilter");
@@ -195,6 +260,94 @@ void AttitudeObserver::addToGUI(const mc_control::MCController & ctl,
                           reset(ctl);
                         }),
                  make_rpy_label("Result", m_orientation));
+
+  gui.addElement(category, ArrayLabel("Accelerometer", [this]() { return m_accIn; }),
+                 ArrayLabel("Gyrometer", [this]() { return m_rateIn; }));
+
+  if(m_gyroBiasFromMeasurement_running)
+  {
+    gui.addElement(category, mc_rtc::gui::ElementsStacking::Horizontal,
+                   ArrayLabel("Gyro Bias (calibrating) :", {"x", "y", "z"},
+                              [this]() -> Eigen::Vector3d { return (m_gyroMeasurementTotal / m_numberOfValues); }),
+                   Button("Stop\ncalibration", [this, &ctl, &gui, &category]() { setGyroBiasToMeanValue(); }));
+  }
+  else
+  {
+    gui.addElement(category, mc_rtc::gui::ElementsStacking::Horizontal, make_xyz_input("Gyro Bias:", m_gyrobias),
+                   Checkbox(
+                       "EKF bias\nestimation", [this]() { return withGyroBias_; },
+                       [this]() { switchWithGyroBias(!withGyroBias_); }),
+                   Button("Calibrate\nfrom data\n(static robot)",
+                          [this, &ctl, &gui, &category]() { startGyroBiasIdentification(); }));
+  }
+
+  auto new_category = category;
+  new_category.push_back("Internal");
+
+  gui.addElement(new_category,
+                 ArrayLabel("Position", [this]() -> Eigen::Vector3d { return xk_.segment<3>(indexes::pos); }),
+                 ArrayLabel("Orientation", [this]() -> Eigen::Vector3d { return xk_.segment<3>(indexes::ori); }),
+                 ArrayLabel("lin vel", [this]() -> Eigen::Vector3d { return xk_.segment<3>(indexes::linVel); }),
+                 ArrayLabel("Ang Vel", [this]() -> Eigen::Vector3d { return xk_.segment<3>(indexes::angVel); }),
+                 ArrayLabel("Lin Acc", [this]() -> Eigen::Vector3d { return xk_.segment<3>(indexes::linAcc); }),
+                 ArrayLabel("Ang Acc", [this]() -> Eigen::Vector3d { return xk_.segment<3>(indexes::angAcc); }));
+}
+
+void AttitudeObserver::setGyroBiasToMeanValue()
+{
+  using namespace mc_rtc::gui;
+
+  m_gyrobias = m_gyroMeasurementTotal / m_numberOfValues;
+  m_gyroBiasFromMeasurement_running = false;
+
+  if(withGyroBias_)
+  {
+    xk_.segment<3>(indexes::gyroBias) = m_gyrobias;
+    filter_.setCurrentState(xk_);
+    Eigen::MatrixXd P = filter_.getStateCovariance();
+    P.block<indexes::gyroBias, 3>(0, indexes::gyroBias).setZero();
+    P.block<3, indexes::gyroBias>(indexes::gyroBias, 0).setZero();
+    P.bottomLeftCorner<3, 3>() = Eigen::Vector3d(Eigen::Vector3d::Constant(config_.biasInitCov)).asDiagonal();
+    filter_.setStateCovariance(P);
+  }
+
+  m_resetGUI = true;
+}
+
+void AttitudeObserver::startGyroBiasIdentification()
+{
+  using namespace mc_rtc::gui;
+
+  m_numberOfValues = 0;
+  m_gyroBiasFromMeasurement_running = true;
+  m_gyroMeasurementTotal.setZero();
+
+  m_resetGUI = true;
+}
+
+void AttitudeObserver::switchWithGyroBias(bool b)
+{
+  if(withGyroBias_ != b)
+  {
+    withGyroBias_ = b;
+    imuFunctor_.setWithGyroBias(b);
+    stateSize_ = imuFunctor_.getStateSize();
+    xk_.conservativeResize(stateSize_);
+    Eigen::MatrixXd P = filter_.getStateCovariance();
+    P.conservativeResize(stateSize_, stateSize_);
+
+    if(withGyroBias_)
+    {
+      xk_.segment<3>(indexes::gyroBias) = m_gyrobias;
+      P.block<indexes::gyroBias, 3>(0, indexes::gyroBias).setZero();
+      P.block<3, indexes::gyroBias>(indexes::gyroBias, 0).setZero();
+      P.bottomLeftCorner<3, 3>() = Eigen::Vector3d(Eigen::Vector3d::Constant(config_.biasInitCov)).asDiagonal();
+    }
+    long time = filter_.getCurrentTime();
+    filter_.setStateSize(stateSize_);
+    filter_.setState(xk_, time);
+    filter_.setStateCovariance(P);
+  }
 }
 
 void AttitudeObserver::KalmanFilterConfig::addToLogger(mc_rtc::Logger & logger, const std::string & category)
@@ -224,6 +377,7 @@ void AttitudeObserver::KalmanFilterConfig::addToGUI(mc_rtc::gui::StateBuilder & 
     make_input_element("gyroCovariance", gyroCovariance),
     make_input_element("orientationAccCov", orientationAccCov),
     make_input_element("linearAccCov", linearAccCov),
+    make_input_element("biasDriftCov", biasDriftCov),
     make_input_element("stateCov", stateCov),
     make_input_element("stateInitCov", stateInitCov),
     make_rpy_input("offset", offset));


### PR DESCRIPTION
This PR allows to calibrate the gyro bias for attitude esitmation while the controller is running. There are two methods to estimating the bias:
-while the robot is static, the user can compute the average measurement (that should be zero).
-using the gyro bias estimator embedded in the same Kalman filter used to estimate the attitude. This estimator can also be initialized with the average estimation coming from the first method.

This requires this PR
https://github.com/jrl-umi3218/mc_rtc/pull/282