### PR TITLE
[WIP][JRP] Update for vision based observer

### DIFF
--- a/include/mc_state_observation/ObjectObserver2.h
+++ b/include/mc_state_observation/ObjectObserver2.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <mc_state_observation/VisionBasedObserver.h>
+#include <geometry_msgs/PoseStamped.h>
+
+namespace mc_state_observation
+{
+
+struct ObjectObserver2 : public VisionBasedObserver
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  ObjectObserver2(const std::string & type, double dt);
+
+  void configure(const mc_control::MCController & ctl, const mc_rtc::Configuration &) override;
+
+  void reset(const mc_control::MCController & ctl) override;
+
+  bool run(const mc_control::MCController & ctl) override;
+
+  void update(mc_control::MCController & ctl) override;
+
+protected:
+  /*! \brief Add observer from logger
+   *
+   * @param category Category in which to log this observer
+   */
+  void addToLogger(const mc_control::MCController &, mc_rtc::Logger &, const std::string & category) override;
+
+  /*! \brief Remove observer from logger
+   *
+   * @param category Category in which this observer entries are logged
+   */
+  void removeFromLogger(mc_rtc::Logger &, const std::string & category) override;
+
+  /*! \brief Add observer information the GUI.
+   *
+   * @param category Category in which to add this observer
+   */
+  void addToGUI(const mc_control::MCController &,
+                mc_rtc::gui::StateBuilder &,
+                const std::vector<std::string> & /* category */) override;
+
+  void updatePose() override;
+
+protected:
+  /*! \brief Callback for ros topic_ defined in the configuration file
+   *
+   * @param msg Message sent by the vision process containing estimated object information
+   */
+  void callback(const geometry_msgs::PoseStamped & msg);
+  void callback2(const geometry_msgs::PoseStamped & msg);
+
+  /// @{
+  std::string object_ = ""; ///< Name of map TF in ROS
+  std::string topic_ = ""; ///< Name of estimated camera TF in ROS
+  ros::Subscriber subscriber_; ///< Subscribe to topic_ name
+  ros::Subscriber subscriber2_; ///< Subscribe to topic_ name
+  sva::PTransformdStamped poseFromTopic_ = {sva::PTransformd::Identity(), 0.0};
+  /// @}
+
+  // Should be deleted in "production"
+  sva::PTransformd local_ = sva::PTransformd::Identity();
+  sva::PTransformdStamped trueCameraPose_ = {sva::PTransformd::Identity(), 0.0};
+  sva::PTransformd truePose_ = sva::PTransformd::Identity();
+
+};
+} // namespace mc_state_observation

--- a/include/mc_state_observation/ObjectObserver2.h
+++ b/include/mc_state_observation/ObjectObserver2.h
@@ -60,7 +60,6 @@ protected:
   /// @}
 
   // Should be deleted in "production"
-  sva::PTransformd local_ = sva::PTransformd::Identity();
   sva::PTransformdStamped trueCameraPose_ = {sva::PTransformd::Identity(), 0.0};
   sva::PTransformd truePose_ = sva::PTransformd::Identity();
 

--- a/include/mc_state_observation/SLAMObserver2.h
+++ b/include/mc_state_observation/SLAMObserver2.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <mc_state_observation/VisionBasedObserver.h>
+#include <tf2_ros/static_transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/transform_broadcaster.h>
+
+namespace mc_state_observation
+{
+
+struct SLAMObserver2 : public VisionBasedObserver
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  SLAMObserver2(const std::string & type, double dt);
+
+  void configure(const mc_control::MCController & ctl, const mc_rtc::Configuration &) override;
+
+  void reset(const mc_control::MCController & ctl) override;
+
+  bool run(const mc_control::MCController & ctl) override;
+
+  void update(mc_control::MCController & ctl) override;
+
+protected:
+  /*! \brief Add observer from logger
+   *
+   * @param category Category in which to log this observer
+   */
+  void addToLogger(const mc_control::MCController &, mc_rtc::Logger &, const std::string & category) override;
+
+  /*! \brief Remove observer from logger
+   *
+   * @param category Category in which this observer entries are logged
+   */
+  void removeFromLogger(mc_rtc::Logger &, const std::string & category) override;
+
+  /*! \brief Add observer information the GUI.
+   *
+   * @param category Category in which to add this observer
+   */
+  void addToGUI(const mc_control::MCController &,
+                mc_rtc::gui::StateBuilder &,
+                const std::vector<std::string> & /* category */) override;
+
+  void updatePose() override;
+
+protected:
+  /// @{
+  std::string body_ = ""; ///< Name of robot's freeflyer
+  mc_rbdyn::Robots robots_; ///< Store robot estimated state
+  /// @}
+
+  /// @{
+  std::string map_ = ""; ///< Name of map TF in ROS
+  std::string estimated_ = ""; ///< Name of estimated camera TF in ROS
+  bool triggerInitialization_ = false; ///< Check if the observer is initialized or not
+  // sva::PTransformdStamped X_Slam_Estimated_Camera_ = {sva::PTransformd::Identity(), 0.0}; ///< Transformation to go from SLAM world to estimated camera
+  /// @}
+
+  /// @{
+  std::string ground_ = "";
+  sva::PTransformdStamped X_Slam_Ground_ = {sva::PTransformd::Identity(), 0.0}; ///< Ground frame in map frame
+  /// @}
+
+  /// @{
+  std::vector<std::string> extraRobotsName_;
+  /// @}
+
+   /// @{
+  tf2_ros::Buffer tfBuffer_;
+  tf2_ros::TransformListener tfListener_{tfBuffer_};
+  tf2_ros::TransformBroadcaster tfBroadcaster_;
+  tf2_ros::StaticTransformBroadcaster tfStaticBroadcaster_;
+  /// @}
+};
+} // namespace mc_state_observation

--- a/include/mc_state_observation/VisionBasedObserver.h
+++ b/include/mc_state_observation/VisionBasedObserver.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <mc_observers/Observer.h>
+#include <mc_rbdyn/Robot.h>
+#include <mc_control/MCController.h>
+#include <SpaceVecAlg/SpaceVecAlg>
+#include <ros/ros.h>
+#include <mc_state_observation/filtering.h>
+#include <boost/circular_buffer.hpp>
+#include <thread>
+
+namespace sva
+{
+  struct PTransformdStamped
+  {
+    sva::PTransformd pose = sva::PTransformd::Identity();
+    double stamp = 0.0;
+  };
+}
+
+namespace mc_rbdyn
+{
+  struct RobotDataStamped
+  {
+    sva::PTransformd freeflyer;
+    sva::PTransformd camera;
+    std::vector<std::vector<double>> q;
+    double stamp = 0.0;
+  };
+}
+
+namespace mc_state_observation
+{
+
+struct VisionBasedObserver : public mc_observers::Observer
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  VisionBasedObserver(const std::string & type, double dt);
+
+  virtual void configure(const mc_control::MCController & ctl, const mc_rtc::Configuration &) override;
+
+  void reset(const mc_control::MCController & ctl) override;
+
+  bool run(const mc_control::MCController & ctl) override;
+
+  virtual void update(mc_control::MCController & ctl) override;
+
+protected:
+
+  /*! \brief Add observer from logger
+   *
+   * @param category Category in which to log this observer
+   */
+  virtual void addToLogger(const mc_control::MCController &, mc_rtc::Logger &, const std::string & category) override;
+
+  /*! \brief Remove observer from logger
+   *
+   * @param category Category in which this observer entries are logged
+   */
+  virtual void removeFromLogger(mc_rtc::Logger &, const std::string & category) override;
+
+  /*! \brief Add observer information the GUI.
+   *
+   * @param category Category in which to add this observer
+   */
+  virtual void addToGUI(const mc_control::MCController &,
+                mc_rtc::gui::StateBuilder &,
+                const std::vector<std::string> & /* category */) override;
+
+  mc_rbdyn::RobotDataStamped robotCameraPoseEstimatedAtStamped(double stamp) const;
+
+  virtual void updatePose() = 0;
+
+  const sva::PTransformd & camera() const;
+
+  const sva::PTransformd & freeflyer() const;
+
+  const std::vector<std::vector<double>> & q() const;
+
+protected:
+
+  /// @{
+  double t_ = 0.0;
+  /// @}
+
+  /// @{
+  std::string robot_ = ""; ///< Name of main robot
+  std::string camera_ = ""; ///< Name of main robot's camera body
+  /// @}
+
+  /// @{
+  bool isEstimatorAlive_ = false;
+  bool isNewEstimatedPose_ = false;
+  /// @}
+
+  /// @{
+  bool isFiltered_ = false; ///< Check if a filter is apply or not
+  std::unique_ptr<filter::Transform> filter_; ///< Filter based on savitzky-golay
+  sva::PTransformdStamped pose_ = {sva::PTransformd::Identity(), 0.0}; ///< Estimated pose
+  /// @}
+
+  /// @{
+  double past_ = 1.0; ////< Time in s to keep the last camera poses
+  boost::circular_buffer<mc_rbdyn::RobotDataStamped> pastRobotData_; ///< Keep the previous camera pose
+  mc_rbdyn::RobotDataStamped robotData_; ///< Robot data with corresponding stamp of pose_ (i.e. of estimatedPose_)
+  sva::PTransformd estimatedPoseFiltered_ = sva::PTransformd::Identity(); ///< Estimated filtered pose
+  sva::PTransformd estimatedPose_ = sva::PTransformd::Identity();
+  /// @}
+
+  /// @{
+  std::shared_ptr<ros::NodeHandle> nh_ = nullptr;
+  std::thread thread_;
+  std::mutex mutex_;
+  double rate_ = 60.0;
+  void rosSpinner();
+  /// @}
+};
+
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,8 +10,16 @@ macro(add_so_observer observer_name)
 endmacro()
 
 macro(add_observer_with_filter observer_name)
+  find_package(gram_savitzky_golay REQUIRED)
   add_observer(${observer_name} "${observer_name}.cpp;filtering.cpp" "${CMAKE_SOURCE_DIR}/include/${PROJECT_NAME}/${observer_name}.h;${CMAKE_SOURCE_DIR}/include/${PROJECT_NAME}/filtering.h")
-  target_link_libraries(${observer_name} PUBLIC mc_rtc::mc_control)
+  target_link_libraries(${observer_name} PUBLIC mc_rtc::mc_control gram_savitzky_golay::gram_savitzky_golay)
+endmacro()
+
+macro(add_vision_based_observer observer_name)
+  find_package(gram_savitzky_golay REQUIRED)
+  add_observer(${observer_name} "${observer_name}.cpp;filtering.cpp;VisionBasedObserver.cpp" "${CMAKE_SOURCE_DIR}/include/${PROJECT_NAME}/${observer_name}.h;${CMAKE_SOURCE_DIR}/include/${PROJECT_NAME}/filtering.h;${CMAKE_SOURCE_DIR}/include/${PROJECT_NAME}/VisionBasedObserver.h")
+  target_link_libraries(${observer_name} PUBLIC mc_rtc::mc_control mc_state_observation::ROS mc_rtc::mc_rtc_ros gram_savitzky_golay::gram_savitzky_golay)
+  set_target_properties(${observer_name} PROPERTIES INSTALL_RPATH ${MC_OBSERVERS_RUNTIME_INSTALL_PREFIX})
 endmacro()
 
 add_so_observer(AttitudeObserver)
@@ -27,9 +35,8 @@ if(${ROSCPP_FOUND})
 endif()
 
 if(${ROSCPP_FOUND})
-  find_package(gram_savitzky_golay REQUIRED)
   add_observer_with_filter(SLAMObserver)
-  target_link_libraries(SLAMObserver PUBLIC mc_rtc::mc_control mc_state_observation::ROS mc_rtc::mc_rtc_ros gram_savitzky_golay::gram_savitzky_golay)
+  target_link_libraries(SLAMObserver PUBLIC mc_rtc::mc_control mc_state_observation::ROS mc_rtc::mc_rtc_ros)
   set_target_properties(SLAMObserver PROPERTIES INSTALL_RPATH ${MC_OBSERVERS_RUNTIME_INSTALL_PREFIX})
 endif()
 
@@ -37,6 +44,11 @@ if(${ROSCPP_FOUND})
   add_simple_observer(ObjectObserver)
   target_link_libraries(ObjectObserver PUBLIC mc_rtc::mc_control mc_state_observation::ROS mc_rtc::mc_rtc_ros)
   set_target_properties(ObjectObserver PROPERTIES INSTALL_RPATH ${MC_OBSERVERS_RUNTIME_INSTALL_PREFIX})
+endif()
+
+if(${ROSCPP_FOUND})
+  add_vision_based_observer(ObjectObserver2)
+  add_vision_based_observer(SLAMObserver2)
 endif()
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/${PROJECT_NAME}

--- a/src/ObjectObserver2.cpp
+++ b/src/ObjectObserver2.cpp
@@ -1,0 +1,143 @@
+
+#include <mc_state_observation/ObjectObserver2.h>
+#include <mc_observers/ObserverMacros.h>
+#include <mc_rtc/version.h>
+#include <SpaceVecAlg/Conversions.h>
+
+#include <tf2_eigen/tf2_eigen.h>
+#include <mc_rtc/ros.h>
+#include <Eigen/src/Geometry/Transform.h>
+
+namespace mc_state_observation
+{
+
+ObjectObserver2::ObjectObserver2(const std::string & type, double dt)
+: VisionBasedObserver(type, dt)
+{
+}
+
+void ObjectObserver2::configure(const mc_control::MCController & ctl, const mc_rtc::Configuration & config)
+{
+  VisionBasedObserver::configure(ctl, config);
+
+  if(config.has("Object"))
+  {
+    object_ = static_cast<std::string>(config("Object")("robot"));
+    topic_ = static_cast<std::string>(config("Object")("topic"));
+  }
+  else
+  {
+    mc_rtc::log::error_and_throw<std::runtime_error>("[{}] Object configuration is mandatory.", name());
+  }
+
+  subscriber_ = nh_->subscribe(topic_, 1, &ObjectObserver2::callback, this);
+  subscriber2_ = nh_->subscribe("/ntm/camera", 1, &ObjectObserver2::callback2, this);
+
+  thread_ = std::thread(std::bind(&ObjectObserver2::rosSpinner, this));
+
+  desc_ = fmt::format("{} (Object: {}, Topic: {})", name(), object_, topic_);
+}
+
+void ObjectObserver2::reset(const mc_control::MCController & ctl)
+{
+  VisionBasedObserver::reset(ctl);
+}
+
+bool ObjectObserver2::run(const mc_control::MCController & ctl)
+{
+  bool ret = VisionBasedObserver::run(ctl);
+  return ret;
+}
+
+void ObjectObserver2::updatePose()
+{
+  const std::lock_guard<std::mutex> lock(mutex_);
+  pose_ = poseFromTopic_;
+}
+
+void ObjectObserver2::update(mc_control::MCController & ctl)
+{
+  VisionBasedObserver::update(ctl);
+
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    if(isNewEstimatedPose_)
+    {
+      isNewEstimatedPose_ = false;
+      local_ = (isFiltered_ ? estimatedPoseFiltered_ : estimatedPose_) * camera();
+      truePose_ = (isFiltered_ ? estimatedPoseFiltered_ : estimatedPose_) * trueCameraPose_.pose;
+      // ctl.realRobot(object_).posW((isFiltered ? estimatedPoseFiltered_ : estimatedPose_));
+    }
+  }
+}
+
+void ObjectObserver2::addToLogger(const mc_control::MCController & ctl,
+                                 mc_rtc::Logger & logger,
+                                 const std::string & category)
+{
+  std::string _category = category;
+  _category += "_" + object_;
+  VisionBasedObserver::addToLogger(ctl, logger, _category);
+
+  logger.addLogEntry(_category + "_posW_control", [this, &ctl]() { return ctl.robot(object_).posW(); });
+  // logger.addLogEntry(_category + "_realPosW", [this, &ctl]() { return ctl.realRobot(object_).posW(); });
+  logger.addLogEntry(_category + "_posW_real", [this, &ctl]() { return local_; });
+  logger.addLogEntry(_category + "_truePose", [this, &ctl]() { return truePose_; });
+  logger.addLogEntry(_category + "_trueCamera", [this, &ctl]() { return trueCameraPose_.pose; });
+}
+
+void ObjectObserver2::removeFromLogger(mc_rtc::Logger & logger, const std::string & category)
+{
+  std::string _category = category;
+  _category += "_" + object_;
+  VisionBasedObserver::removeFromLogger(logger, category);
+
+  logger.removeLogEntry(_category + "_posW_control");
+  logger.removeLogEntry(_category + "_posW_real");
+  logger.removeLogEntry(_category + "_truePose");
+  logger.removeLogEntry(_category + "_trueCamera");
+}
+
+void ObjectObserver2::addToGUI(const mc_control::MCController & ctl,
+                              mc_rtc::gui::StateBuilder & gui,
+                              const std::vector<std::string> & category)
+{
+  VisionBasedObserver::addToGUI(ctl, gui, category);
+
+  using namespace mc_rtc::gui;
+
+  gui.addElement(category,
+    Transform("realPose_" + object_, [this, &ctl]() { return ctl.realRobot(object_).posW(); })
+  );
+}
+
+void ObjectObserver2::callback(const geometry_msgs::PoseStamped & msg)
+{
+  Eigen::Affine3d affine;
+  tf2::fromMsg(msg.pose, affine);
+  const sva::PTransformd pose = sva::conversions::fromHomogeneous(affine.matrix());
+  const sva::MotionVecd error = sva::transformError(pose, poseFromTopic_.pose);
+  const std::lock_guard<std::mutex> lock(mutex_);
+  if((poseFromTopic_.pose == sva::PTransformd::Identity()) ||
+      (poseFromTopic_.pose != sva::PTransformd::Identity() && error.vector().norm() < 0.5))
+  {
+    poseFromTopic_ = {pose, msg.header.stamp.toSec()};
+    isNewEstimatedPose_ = true;
+    isEstimatorAlive_ = true;
+  }
+  else
+  {
+    isEstimatorAlive_ = false;
+  }
+}
+
+void ObjectObserver2::callback2(const geometry_msgs::PoseStamped & msg)
+{
+  Eigen::Affine3d affine;
+  tf2::fromMsg(msg.pose, affine);
+  trueCameraPose_ = {sva::conversions::fromHomogeneous(affine.matrix()), msg.header.stamp.toSec()};
+}
+
+} // namespace mc_state_observation
+
+EXPORT_OBSERVER_MODULE("Object2", mc_state_observation::ObjectObserver2)

--- a/src/ObjectObserver2.cpp
+++ b/src/ObjectObserver2.cpp
@@ -130,6 +130,7 @@ void ObjectObserver2::callback(const geometry_msgs::PoseStamped & msg)
   else
   {
     isEstimatorAlive_ = false;
+    poseFromTopic_ = {sva::PTransformd::Identity(), 0.0};
   }
 }
 

--- a/src/ObjectObserver2.cpp
+++ b/src/ObjectObserver2.cpp
@@ -1,20 +1,17 @@
 
-#include <mc_state_observation/ObjectObserver2.h>
 #include <mc_observers/ObserverMacros.h>
 #include <mc_rtc/version.h>
 #include <SpaceVecAlg/Conversions.h>
+#include <mc_state_observation/ObjectObserver2.h>
 
-#include <tf2_eigen/tf2_eigen.h>
 #include <mc_rtc/ros.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <Eigen/src/Geometry/Transform.h>
 
 namespace mc_state_observation
 {
 
-ObjectObserver2::ObjectObserver2(const std::string & type, double dt)
-: VisionBasedObserver(type, dt)
-{
-}
+ObjectObserver2::ObjectObserver2(const std::string & type, double dt) : VisionBasedObserver(type, dt) {}
 
 void ObjectObserver2::configure(const mc_control::MCController & ctl, const mc_rtc::Configuration & config)
 {
@@ -72,8 +69,8 @@ void ObjectObserver2::update(mc_control::MCController & ctl)
 }
 
 void ObjectObserver2::addToLogger(const mc_control::MCController & ctl,
-                                 mc_rtc::Logger & logger,
-                                 const std::string & category)
+                                  mc_rtc::Logger & logger,
+                                  const std::string & category)
 {
   std::string _category = category;
   _category += "_" + object_;
@@ -99,16 +96,14 @@ void ObjectObserver2::removeFromLogger(mc_rtc::Logger & logger, const std::strin
 }
 
 void ObjectObserver2::addToGUI(const mc_control::MCController & ctl,
-                              mc_rtc::gui::StateBuilder & gui,
-                              const std::vector<std::string> & category)
+                               mc_rtc::gui::StateBuilder & gui,
+                               const std::vector<std::string> & category)
 {
   VisionBasedObserver::addToGUI(ctl, gui, category);
 
   using namespace mc_rtc::gui;
 
-  gui.addElement(category,
-    Transform("realPose_" + object_, [this, &ctl]() { return ctl.realRobot(object_).posW(); })
-  );
+  gui.addElement(category, Transform("realPose_" + object_, [this, &ctl]() { return ctl.realRobot(object_).posW(); }));
 }
 
 void ObjectObserver2::callback(const geometry_msgs::PoseStamped & msg)
@@ -118,8 +113,8 @@ void ObjectObserver2::callback(const geometry_msgs::PoseStamped & msg)
   const sva::PTransformd pose = sva::conversions::fromHomogeneous(affine.matrix());
   const sva::MotionVecd error = sva::transformError(pose, poseFromTopic_.pose);
   const std::lock_guard<std::mutex> lock(mutex_);
-  if((poseFromTopic_.pose == sva::PTransformd::Identity()) ||
-      (poseFromTopic_.pose != sva::PTransformd::Identity() && error.vector().norm() < 0.5))
+  if((poseFromTopic_.pose == sva::PTransformd::Identity())
+     || (poseFromTopic_.pose != sva::PTransformd::Identity() && error.vector().norm() < 0.5))
   {
     poseFromTopic_ = {pose, msg.header.stamp.toSec()};
     isNewEstimatedPose_ = true;

--- a/src/ObjectObserver2.cpp
+++ b/src/ObjectObserver2.cpp
@@ -61,9 +61,8 @@ void ObjectObserver2::update(mc_control::MCController & ctl)
     if(isNewEstimatedPose_)
     {
       isNewEstimatedPose_ = false;
-      local_ = (isFiltered_ ? estimatedPoseFiltered_ : estimatedPose_) * camera();
       truePose_ = (isFiltered_ ? estimatedPoseFiltered_ : estimatedPose_) * trueCameraPose_.pose;
-      // ctl.realRobot(object_).posW((isFiltered ? estimatedPoseFiltered_ : estimatedPose_));
+      ctl.realRobot(object_).posW((isFiltered_ ? estimatedPoseFiltered_ : estimatedPose_) * camera());
     }
   }
 }
@@ -77,8 +76,7 @@ void ObjectObserver2::addToLogger(const mc_control::MCController & ctl,
   VisionBasedObserver::addToLogger(ctl, logger, _category);
 
   logger.addLogEntry(_category + "_posW_control", [this, &ctl]() { return ctl.robot(object_).posW(); });
-  // logger.addLogEntry(_category + "_realPosW", [this, &ctl]() { return ctl.realRobot(object_).posW(); });
-  logger.addLogEntry(_category + "_posW_real", [this, &ctl]() { return local_; });
+  logger.addLogEntry(_category + "_posW_real", [this, &ctl]() { return ctl.realRobot(object_).posW(); });
   logger.addLogEntry(_category + "_truePose", [this, &ctl]() { return truePose_; });
   logger.addLogEntry(_category + "_trueCamera", [this, &ctl]() { return trueCameraPose_.pose; });
 }

--- a/src/ObjectObserver2.cpp
+++ b/src/ObjectObserver2.cpp
@@ -30,6 +30,15 @@ void ObjectObserver2::configure(const mc_control::MCController & ctl, const mc_r
   subscriber_ = nh_->subscribe(topic_, 1, &ObjectObserver2::callback, this);
   subscriber2_ = nh_->subscribe("/ntm/camera", 1, &ObjectObserver2::callback2, this);
 
+  const_cast<mc_control::MCController &>(ctl).datastore().make_call(
+    object_+"::X_C_Object",
+    [this]() -> const sva::PTransformd &
+    {
+      const std::lock_guard<std::mutex> lock(mutex_);
+      return isFiltered_ ? estimatedPoseFiltered_ : estimatedPose_;
+    }
+  );
+
   thread_ = std::thread(std::bind(&ObjectObserver2::rosSpinner, this));
 
   desc_ = fmt::format("{} (Object: {}, Topic: {})", name(), object_, topic_);

--- a/src/SLAMObserver2.cpp
+++ b/src/SLAMObserver2.cpp
@@ -183,7 +183,12 @@ void SLAMObserver2::update(mc_control::MCController & ctl)
 
     for(auto & robot : robots_)
     {
-      robot.posW(ctl.realRobot(robot.name()).posW() * ctl.realRobot().posW().inv() * main_robot.posW());
+      // This rely on real robot estimation which might be wrong
+      // robot.posW(ctl.realRobot(robot.name()).posW() * ctl.realRobot().posW().inv() * main_robot.posW());
+      // Instead rely only on vSLAM camera estimation and corresponding object pose estimation
+
+      const sva::PTransformd X_C_Object = ctl.datastore().call<sva::PTransformd>(robot.name()+"::X_C_Object");
+      robot.posW(X_C_Object * camera());
       mc_rtc::ROSBridge::update_robot_publisher("SLAM_" + robot.name(), ctl.timeStep, robot);
     }
   }

--- a/src/SLAMObserver2.cpp
+++ b/src/SLAMObserver2.cpp
@@ -205,6 +205,9 @@ void SLAMObserver2::addToLogger(const mc_control::MCController & ctl,
   logger.addLogEntry(category + "_LeftFootCenter", [this]() { return robots_.robot().surfacePose("LeftFootCenter"); });
   logger.addLogEntry(category + "_RightFootCenter",
                      [this]() { return robots_.robot().surfacePose("RightFootCenter"); });
+  logger.addLogEntry(category + "_InternLeftHand", [this]() { return robots_.robot().surfacePose("InternLeftHand"); });
+  logger.addLogEntry(category + "_InternRightHand",
+                     [this]() { return robots_.robot().surfacePose("InternRightHand"); });
   logger.addLogEntry(category + "_com", [this]() { return robots_.robot().com(); });
 
   for(auto & robot : robots_)

--- a/src/SLAMObserver2.cpp
+++ b/src/SLAMObserver2.cpp
@@ -157,13 +157,8 @@ void SLAMObserver2::update(mc_control::MCController & ctl)
   if(isNewEstimatedPose_)
   {
     isNewEstimatedPose_ = false;
-    // if(ctl.datastore().has("SLAM::Robot"))
-    // {
-    //   ctl.datastore().remove("SLAM::Robot");
-    // }
 
     auto & main_robot = robots_.robot();
-
     main_robot.mbc().q = q();
     const sva::PTransformd robot_posW =
         freeflyer() * camera().inv() * (isFiltered_ ? estimatedPoseFiltered_ : estimatedPose_);

--- a/src/SLAMObserver2.cpp
+++ b/src/SLAMObserver2.cpp
@@ -1,0 +1,216 @@
+#include <mc_state_observation/SLAMObserver2.h>
+#include <mc_observers/ObserverMacros.h>
+#include <mc_rtc/version.h>
+#include <SpaceVecAlg/Conversions.h>
+
+#include <tf2_eigen/tf2_eigen.h>
+#include <mc_rtc/ros.h>
+#include <Eigen/src/Geometry/Transform.h>
+
+namespace mc_state_observation
+{
+
+namespace
+{
+
+bool getTransformStamped(tf2_ros::Buffer & tfBuffer, const std::string & origin, const std::string & to,
+  geometry_msgs::TransformStamped & transformStamped, std::string & error)
+{
+  try
+  {
+    transformStamped = tfBuffer.lookupTransform(origin, to, ros::Time(0));
+  }
+  catch(tf2::TransformException & ex)
+  {
+    error = fmt::format("[SLAMObserver2] Could not get transform from \"{}\" to \"{}\"", origin, to);
+    return false;
+  }
+  return true;
+}
+
+}
+
+SLAMObserver2::SLAMObserver2(const std::string & type, double dt)
+: VisionBasedObserver(type, dt)
+{
+}
+
+void SLAMObserver2::configure(const mc_control::MCController & ctl, const mc_rtc::Configuration & config)
+{
+  VisionBasedObserver::configure(ctl, config);
+
+  if(config.has("Robot"))
+  {
+    body_ = ctl.robot(robot_).mb().bodies()[0].name();
+    robots_.load({ctl.robot(robot_).module()});
+  }
+
+  if(config.has("SLAM"))
+  {
+    map_ = static_cast<std::string>(config("SLAM")("map"));
+    estimated_ = static_cast<std::string>(config("SLAM")("estimated"));
+    if(config("SLAM").has("ground"))
+    {
+      ground_ = static_cast<std::string>(config("SLAM")("ground"));
+    }
+  }
+  else
+  {
+    mc_rtc::log::error_and_throw<std::runtime_error>("[{}] SLAM configuration is mandatory.", name());
+  }
+
+  if(config.has("ExtraRobots"))
+  {
+    extraRobotsName_ = config("ExtraRobots");
+    for(const auto & name : extraRobotsName_)
+    {
+      robots_.load(name, ctl.robot(name).module());
+    }
+  }
+
+  desc_ = fmt::format("{} (Camera: {}, Estimated: {}, ExtraRobots: {})", name(), camera_, estimated_, fmt::join(extraRobotsName_, ", "));
+
+  thread_ = std::thread(std::bind(&SLAMObserver2::rosSpinner, this));
+}
+
+void SLAMObserver2::reset(const mc_control::MCController & ctl)
+{
+  VisionBasedObserver::reset(ctl);
+}
+
+bool SLAMObserver2::run(const mc_control::MCController & ctl)
+{
+  if(triggerInitialization_)
+  {
+    triggerInitialization_ = false;
+
+    geometry_msgs::TransformStamped transformStamped;
+    if(!getTransformStamped(tfBuffer_, map_, estimated_, transformStamped, error_))
+    {
+      isEstimatorAlive_ = false;
+      return false;
+    }
+
+    const sva::PTransformd X_Slam_Estimated_Camera = sva::conversions::fromHomogeneous(tf2::transformToEigen(transformStamped).matrix());
+
+    // Connect SLAM and Robot map, just for visual purpose
+    const sva::PTransformd X_0_S = X_Slam_Estimated_Camera.inv() * ctl.realRobot(robot_).bodyPosW(camera_);
+
+    auto transform = tf2::eigenToTransform(sva::conversions::toAffine(X_0_S));
+    transform.header.stamp = ros::Time::now();
+    transform.header.frame_id = "robot_map";
+    transform.child_frame_id = map_;
+    tfStaticBroadcaster_.sendTransform(transform);
+
+    filter_->reset();
+  }
+
+  geometry_msgs::TransformStamped transformStamped;
+  if(!getTransformStamped(tfBuffer_, "robot_map", estimated_, transformStamped, error_))
+  {
+    isEstimatorAlive_ = false;
+    return false;
+  }
+
+  isEstimatorAlive_ = true;
+
+  isNewEstimatedPose_ = false;
+  const sva::PTransformd pose = sva::conversions::fromHomogeneous(tf2::transformToEigen(transformStamped).matrix());
+  if(pose != pose_.pose)
+  {
+    pose_.pose = pose;
+    pose_.stamp = transformStamped.header.stamp.toSec();
+    isNewEstimatedPose_ = true;
+  }
+
+  return VisionBasedObserver::run(ctl);
+}
+
+void SLAMObserver2::updatePose()
+{
+  geometry_msgs::TransformStamped transformStamped;
+  if(ground_ != "" && getTransformStamped(tfBuffer_, map_, ground_, transformStamped, error_))
+  {
+    X_Slam_Ground_.pose = sva::conversions::fromHomogeneous(tf2::transformToEigen(transformStamped).matrix());
+    X_Slam_Ground_.stamp = transformStamped.header.stamp.toSec();
+  }
+}
+
+void SLAMObserver2::update(mc_control::MCController & ctl)
+{
+  VisionBasedObserver::update(ctl);
+
+  if(isNewEstimatedPose_)
+  {
+    isNewEstimatedPose_ = false;
+    // if(ctl.datastore().has("SLAM::Robot"))
+    // {
+    //   ctl.datastore().remove("SLAM::Robot");
+    // }
+
+    auto & main_robot = robots_.robot();
+
+    main_robot.mbc().q = q();
+    const sva::PTransformd robot_posW = freeflyer() * camera().inv() * (isFiltered_ ? estimatedPoseFiltered_ : estimatedPose_);
+    main_robot.posW(robot_posW);
+
+    for(auto & robot: robots_)
+    {
+      robot.posW(ctl.realRobot(robot.name()).posW() * ctl.realRobot().posW().inv() * main_robot.posW());
+      mc_rtc::ROSBridge::update_robot_publisher("SLAM_"+robot.name(), ctl.timeStep, robot);
+    }
+  }
+}
+
+void SLAMObserver2::addToLogger(const mc_control::MCController & ctl, mc_rtc::Logger & logger, const std::string & category)
+{
+  VisionBasedObserver::addToLogger(ctl, logger, category);
+  logger.addLogEntry(category + "_LeftFootCenter", [this]() { return robots_.robot().surfacePose("LeftFootCenter"); });
+  logger.addLogEntry(category + "_RightFootCenter", [this]() { return robots_.robot().surfacePose("RightFootCenter"); });
+  logger.addLogEntry(category + "_com", [this]() { return robots_.robot().com(); });
+
+  for(auto & robot: robots_)
+  {
+    const std::string & name = robot.name();
+    logger.addLogEntry(category + "_posW_" + name, [this, name]() { return robots_.robot(name).posW(); });
+  }
+}
+
+void SLAMObserver2::removeFromLogger(mc_rtc::Logger & logger, const std::string & category)
+{
+  VisionBasedObserver::removeFromLogger(logger, category);
+  logger.removeLogEntry(category + "_LeftFootCenter");
+  logger.removeLogEntry(category + "_RightFootCenter");
+  logger.removeLogEntry(category + "_com");
+
+  for(auto & robot: robots_)
+  {
+    logger.removeLogEntry(category + "_posW_" + robot.name());
+  }
+}
+
+void SLAMObserver2::addToGUI(const mc_control::MCController & ctl,
+                            mc_rtc::gui::StateBuilder & gui,
+                            const std::vector<std::string> & category)
+{
+  VisionBasedObserver::addToGUI(ctl, gui, category);
+
+  using namespace mc_rtc::gui;
+
+  gui.addElement(category, Transform("X_S_Ground", [this]() { return X_Slam_Ground_.pose; }),
+                 Button("Initialize",
+                        [this, &ctl]() {
+                          triggerInitialization_ = true;
+                        }),
+                 ArrayLabel("X_Slam_Camera", {"r", "p", "y", "x", "y", "z"},
+                            [this]() {
+                              Eigen::VectorXd ret(6);
+                              ret << mc_rbdyn::rpyFromMat(pose_.pose.rotation()), pose_.pose.translation();
+                              return ret;
+                            })
+  );
+}
+
+} // namespace mc_state_observation
+
+EXPORT_OBSERVER_MODULE("SLAM2", mc_state_observation::SLAMObserver2)

--- a/src/SLAMObserver2.cpp
+++ b/src/SLAMObserver2.cpp
@@ -114,6 +114,14 @@ bool SLAMObserver2::run(const mc_control::MCController & ctl)
     {
       const_cast<mc_control::MCController &>(ctl).datastore().remove("SLAM::Robot");
       const_cast<mc_control::MCController &>(ctl).datastore().remove("SLAM::X_S_Ground");
+
+      for(size_t i = 0; i < robots_.robots().size(); ++i)
+      {
+        if(i != robots_.robotIndex())
+        {
+          const_cast<mc_control::MCController &>(ctl).datastore().remove(robots_.robots()[i].name()+"::X_S_Object");
+        }
+      }
     }
     isEstimatorAlive_ = false;
     return false;
@@ -126,6 +134,15 @@ bool SLAMObserver2::run(const mc_control::MCController & ctl)
         "SLAM::Robot", [this]() -> const mc_rbdyn::Robot & { return robots_.robot(); });
     const_cast<mc_control::MCController &>(ctl).datastore().make_call(
         "SLAM::X_S_Ground", [this]() -> const sva::PTransformd & { return X_Slam_Ground_.pose; });
+
+    for(size_t i = 0; i < robots_.robots().size(); ++i)
+    {
+      if(i != robots_.robotIndex())
+      {
+        const_cast<mc_control::MCController &>(ctl).datastore().make_call(
+          robots_.robots()[i].name()+"::X_S_Object", [this, i]() -> const sva::PTransformd & { return robots_.robots()[i].posW(); });
+      }
+    }
   }
 
   isNewEstimatedPose_ = false;

--- a/src/VisionBasedObserver.cpp
+++ b/src/VisionBasedObserver.cpp
@@ -1,0 +1,256 @@
+#include <mc_state_observation/VisionBasedObserver.h>
+#include <mc_observers/ObserverMacros.h>
+#include <mc_rtc/ros.h>
+#include <mc_rtc/version.h>
+#include <SpaceVecAlg/Conversions.h>
+#include <mc_state_observation/gui_helpers.h>
+
+// Remove if using C++20
+namespace std
+{
+  double lerp(double a, double b, double f)
+  {
+    return a + f * (b - a);
+  }
+}
+
+namespace mc_state_observation
+{
+
+VisionBasedObserver::VisionBasedObserver(const std::string & type, double dt)
+: mc_observers::Observer(type, dt),
+  nh_(mc_rtc::ROSBridge::get_node_handle())
+{
+}
+
+void VisionBasedObserver::configure(const mc_control::MCController & ctl, const mc_rtc::Configuration & config)
+{
+  if(config.has("Robot"))
+  {
+    robot_ = config("Robot")("robot", ctl.robot().name());
+    camera_ = static_cast<std::string>(config("Robot")(robot_)("camera"));
+    if(!ctl.robot(robot_).hasBody(camera_))
+    {
+      mc_rtc::log::error_and_throw<std::runtime_error>("No {} body found in {}", camera_, robot_);
+    }
+  }
+  else
+  {
+    mc_rtc::log::error_and_throw<std::runtime_error>("[{}] Robot configuration is mandatory.", name());
+  }
+
+  int m = 50;
+  int d = 0;
+  int n = 3;
+  if(config.has("Filter"))
+  {
+    isFiltered_ = config("Filter")("use", false);
+    m = config("Filter")("m", static_cast<int>(m));
+    d = config("Filter")("d", static_cast<int>(d));
+    n = config("Filter")("n", static_cast<int>(n));
+  }
+
+  auto sg_conf = gram_sg::SavitzkyGolayFilterConfig(m, m, n, d);
+  filter_.reset(new filter::Transform(sg_conf));
+
+  if(config.has("past"))
+  {
+    past_ = config("past");
+  }
+
+  if(config.has("rate"))
+  {
+    rate_ = config("rate");
+  }
+
+  pastRobotData_ = boost::circular_buffer<mc_rbdyn::RobotDataStamped>(
+    static_cast<long unsigned int>(std::ceil(past_ / ctl.solver().dt())));
+}
+
+void VisionBasedObserver::reset(const mc_control::MCController &)
+{
+}
+
+bool VisionBasedObserver::run(const mc_control::MCController & ctl)
+{
+  // Keep in memory the past camera of real robot
+  pastRobotData_.push_back({ctl.realRobot().posW(), ctl.realRobot().bodyPosW(camera_),
+    ctl.realRobot().mbc().q, ros::Time::now().toSec()});
+  t_ += ctl.solver().dt();
+
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    if(!isEstimatorAlive_)
+    {
+      error_ = fmt::format("[{}] The estimator is no more alive.", name());
+      return false;
+    }
+  }
+
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    if(!isNewEstimatedPose_)
+    {
+      return true;
+    }
+  }
+
+  updatePose();
+
+  estimatedPose_ = pose_.pose;
+  filter_->add(estimatedPose_);
+  if(filter_->ready())
+  {
+    estimatedPoseFiltered_ = filter_->filter();
+  }
+
+  robotData_ = robotCameraPoseEstimatedAtStamped(pose_.stamp);
+
+  return true;
+}
+
+void VisionBasedObserver::update(mc_control::MCController &)
+{
+}
+
+void VisionBasedObserver::addToLogger(const mc_control::MCController & ctl,
+                                 mc_rtc::Logger & logger,
+                                 const std::string & category)
+{
+  logger.addLogEntry(category + "_estimated_pose", [this]() { return estimatedPose_; });
+  logger.addLogEntry(category + "_estimated_filteredPose", [this]() { return estimatedPoseFiltered_; });
+
+  logger.addLogEntry(category + "_camera_control", [this, &ctl]() { return ctl.robot().bodyPosW(camera_); });
+  logger.addLogEntry(category + "_camera_real", [this, &ctl]() { return ctl.realRobot().bodyPosW(camera_); });
+  logger.addLogEntry(category + "_camera_interpolate", [this]() { return camera(); });
+
+  logger.addLogEntry(category + "_robot_control", [this, &ctl]() { return ctl.robot().posW(); });
+  logger.addLogEntry(category + "_robot_real", [this, &ctl]() { return ctl.realRobot().posW(); });
+  logger.addLogEntry(category + "_robot_interpolate", [this]() { return freeflyer(); });
+}
+
+void VisionBasedObserver::removeFromLogger(mc_rtc::Logger & logger, const std::string & category)
+{
+  logger.removeLogEntry(category + "_estimated_pose");
+  logger.removeLogEntry(category + "_estimated_filteredPose");
+
+  logger.removeLogEntry(category + "_camera_control");
+  logger.removeLogEntry(category + "_camera_real");
+  logger.removeLogEntry(category + "_camera_interpolate");
+
+  logger.removeLogEntry(category + "_robot_control");
+  logger.removeLogEntry(category + "_robot_real");
+  logger.removeLogEntry(category + "_robot_interpolate");
+
+}
+
+void VisionBasedObserver::addToGUI(const mc_control::MCController &,
+                              mc_rtc::gui::StateBuilder & gui,
+                              const std::vector<std::string> & category)
+{
+  using namespace mc_rtc::gui;
+
+  std::vector<std::string> categoryFilter = category;
+  categoryFilter.push_back("Filter");
+  gui.addElement(
+    categoryFilter,
+    Button("Toggle filter",
+            [this]() {
+              isFiltered_ = !isFiltered_;
+              if(isFiltered_)
+              {
+                filter_->reset();
+              }
+            }),
+    Label("Apply filter:", [this]() { return (isFiltered_ ? "yes" : "no"); }),
+    ArrayInput("Filter config", {"m", "d", "n"},
+                [this]() { return Eigen::Vector3d(filter_->config().m, filter_->config().s, filter_->config().n); },
+                [this](const Eigen::Vector3d & v) {
+                  int m = static_cast<int>(v.x());
+                  int d = static_cast<int>(v.y());
+                  int n = static_cast<int>(v.z());
+                  auto sg_conf = gram_sg::SavitzkyGolayFilterConfig(m, m, n, d);
+                  filter_.reset(new filter::Transform(sg_conf));
+                  filter_->reset();
+                }));
+
+
+  gui.addPlot(name()+"_translation", mc_rtc::gui::plot::X("t", [this]() { return t_; }),
+              // mc_rtc::gui::plot::Y("x_f", [this]() { return estimatedPoseFiltered_.translation().x(); },
+              //                      mc_rtc::gui::Color::Red),
+              // mc_rtc::gui::plot::Y("x", [this]() { return estimatedPose_.translation().x(); },
+              //                      mc_rtc::gui::Color::Red, mc_rtc::gui::plot::Style::Dotted),
+              mc_rtc::gui::plot::Y("y_f", [this]() { return estimatedPoseFiltered_.translation().y(); },
+                                   mc_rtc::gui::Color::Red),
+              mc_rtc::gui::plot::Y("y", [this]() { return estimatedPose_.translation().y(); },
+                                   mc_rtc::gui::Color::Blue, mc_rtc::gui::plot::Style::Dotted)
+              // mc_rtc::gui::plot::Y("z_f", [this]() { return estimatedPoseFiltered_.translation().z(); },
+              //                      mc_rtc::gui::Color::Blue),
+              // mc_rtc::gui::plot::Y("z", [this]() { return estimatedPose_.translation().z(); },
+              //                      mc_rtc::gui::Color::Blue, mc_rtc::gui::plot::Style::Dotted)
+  );
+}
+
+mc_rbdyn::RobotDataStamped VisionBasedObserver::robotCameraPoseEstimatedAtStamped(double stamp) const
+{
+  mc_rbdyn::RobotDataStamped previous;
+
+  int i = static_cast<int>(pastRobotData_.size()) - 1;
+  for(; i >= 0; --i)
+  {
+    previous = pastRobotData_[i];
+    if(previous.stamp < stamp)
+    {
+      break;
+    }
+  }
+
+  if(i >= 0 && i <= static_cast<int>(pastRobotData_.size()) - 2)
+  {
+    const mc_rbdyn::RobotDataStamped & next = pastRobotData_[i + 1];
+    // interpolate
+    double ratio = (stamp - previous.stamp) / (next.stamp - previous.stamp);
+    previous.camera = sva::interpolate(previous.camera, next.camera, ratio);
+    previous.freeflyer = sva::interpolate(previous.freeflyer, next.freeflyer, ratio);
+
+    for(size_t m = 1; m < previous.q.size(); ++m)
+    {
+      for(size_t n = 0; n < previous.q[m].size(); ++n)
+      {
+        previous.q[m][n] = std::lerp(previous.q[m][n], next.q[m][n], ratio);
+      }
+    }
+  }
+
+  return previous;
+}
+
+
+const sva::PTransformd & VisionBasedObserver::camera() const
+{
+  return robotData_.camera;
+}
+
+const sva::PTransformd & VisionBasedObserver::freeflyer() const
+{
+  return robotData_.freeflyer;
+}
+
+const std::vector<std::vector<double>> & VisionBasedObserver::q() const
+{
+  return robotData_.q;
+}
+
+void VisionBasedObserver::rosSpinner()
+{
+  mc_rtc::log::info("[{}] rosSpinner started", name());
+  ros::Rate rate(rate_); // At least 2 times the rate of the estimation
+  while(ros::ok())
+  {
+    ros::spinOnce();
+    rate.sleep();
+  }
+  mc_rtc::log::info("[{}] rosSpinner finished", name());
+}
+
+} // namespace mc_state_observation


### PR DESCRIPTION
@Dwaaap @mmurooka 

On the robot I found that you were using this version of the `Object/SLAM` observers, namely `Object2` and `SLAM2`.
From the naming I'm guessing that this is some sort of (unfinished?) rewrite of the original observers.

So could you let me know:
- what's the status on that?
- what does this change w.r.t the original observers?
- do we need to use these observers for the JRP demo?