### PR TITLE
[AttitudeObserver] Apply transpose to rotation in log and GUI

### DIFF
--- a/src/AttitudeObserver.cpp
+++ b/src/AttitudeObserver.cpp
@@ -162,7 +162,7 @@ void AttitudeObserver::addToLogger(const mc_control::MCController &,
                                    const std::string & category)
 {
   logger.addLogEntry(category + "_orientation", [this]() -> sva::PTransformd {
-    return sva::PTransformd{m_orientation, Eigen::Vector3d::Zero()};
+    return sva::PTransformd{m_orientation.transpose(), Eigen::Vector3d::Zero()};
   });
   if(log_kf_)
   {
@@ -194,7 +194,7 @@ void AttitudeObserver::addToGUI(const mc_control::MCController & ctl,
                           mc_rtc::log::info("[{}] Manual reset triggerred", name());
                           reset(ctl);
                         }),
-                 make_rpy_label("Result", m_orientation));
+                 make_rpy_label("Result", m_orientation.transpose()));
 }
 
 void AttitudeObserver::KalmanFilterConfig::addToLogger(mc_rtc::Logger & logger, const std::string & category)


### PR DESCRIPTION
Both rotations are passed to functions that assume mc_rtc rotation convention.