### PR TITLE
[Attitude] Fix initialization on the first iteration

### DIFF
--- a/src/AttitudeObserver.cpp
+++ b/src/AttitudeObserver.cpp
@@ -71,7 +71,14 @@ void AttitudeObserver::reset(const mc_control::MCController & ctl)
 
   uk_.setZero();
 
-  filter_.setState(xk_, filter_.getCurrentTime());
+  if(filter_.stateIsSet())
+  {
+    filter_.setState(xk_, filter_.getCurrentTime());
+  }
+  else
+  {
+    filter_.setState(xk_, 0);
+  }
   filter_.setStateCovariance(so::Matrix::Identity(STATE_SIZE, STATE_SIZE) * c.stateInitCov);
 
   lastStateInitCovariance_ = c.stateInitCov;


### PR DESCRIPTION
This avoids the assertion fired on the first iteration when the state has not been set yet.