### PR TITLE
Add MCKineticsObserver and TiltObserver

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,10 @@ repos:
   - id: check-executables-have-shebangs
   - id: check-merge-conflict
   - id: check-yaml
+    exclude: |
+      (?x)^(
+          tests/mc_rtc.in.yaml|
+      )$
   - id: debug-statements
   - id: destroyed-symlinks
   - id: detect-private-key

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,3 +47,7 @@ if(WITH_ROS_OBSERVERS)
 endif()
 
 add_subdirectory(src)
+
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/include/mc_state_observation/MCKineticsObserver.h
+++ b/include/mc_state_observation/MCKineticsObserver.h
@@ -1,0 +1,502 @@
+/* Copyright 2017-2020 CNRS-AIST JRL, CNRS-UM LIRMM */
+
+#pragma once
+
+#include <mc_rbdyn/Contact.h>
+#include <mc_rbdyn/Robot.h>
+#include <boost/circular_buffer.hpp>
+#include <mc_state_observation/observersTools/measurementsTools.h>
+#include <state-observation/dynamics-estimators/kinetics-observer.hpp>
+
+#include <mc_observers/Observer.h>
+
+namespace mc_state_observation
+{
+/** Interface for the use of the Kinetics Observer within mc_rtc: \n
+ * The Kinetics Observer requires inputs expressed in the frame of the floating base. It then performs a conversion to
+ *the centroid frame, a frame located at the center of mass of the robot and with the orientation of the floating
+ *base of the real robot.
+ *The inputs are obtained from a robot called the inputRobot. Its configuration is the one of real robot, but
+ *its floating base's frame is superimposed with the world frame. This allows to ease computations performed in the
+ *local frame of the robot.
+ *The Kinetics Observer is associated to the Tilt Observer as a backup. If an anomaly is detected, the Kinetics Observer
+ *will recover the last ellapsed second (or less) using the displacement made by the Tilt Observer.
+ **/
+
+/// @brief Class containing the information of a contact.
+/// @details This class is an enhancement of the ContactWithSensor class with the kinematics of the contact in the
+/// floating base and the kinematics of the frame of the sensor in the frame of the contact surface
+struct KoContactWithSensor : public measurements::ContactWithSensor
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+protected:
+  KoContactWithSensor() {}
+
+public:
+  KoContactWithSensor(int id, std::string forceSensorName)
+  {
+    id_ = id;
+    name_ = forceSensorName;
+    forceSensorName_ = forceSensorName;
+
+    resetContact();
+  }
+
+  KoContactWithSensor(int id,
+                      const std::string & forceSensorName,
+                      const std::string & surfaceName,
+                      bool sensorAttachedToSurface)
+  {
+    id_ = id;
+    name_ = forceSensorName;
+    resetContact();
+
+    surface_ = surfaceName;
+    forceSensorName_ = forceSensorName;
+    sensorAttachedToSurface_ = sensorAttachedToSurface;
+  }
+
+public:
+  // kinematics of the contact frame in the floating base's frame
+  stateObservation::kine::Kinematics fbContactKine_;
+  // kinematics of the sensor frame in the frame of the contact surface
+  stateObservation::kine::Kinematics surfaceSensorKine_;
+};
+
+struct MCKineticsObserver : public mc_observers::Observer
+{
+
+  MCKineticsObserver(const std::string & type, double dt);
+
+  void configure(const mc_control::MCController & ctl, const mc_rtc::Configuration &) override;
+
+  void reset(const mc_control::MCController & ctl) override;
+
+  bool run(const mc_control::MCController & ctl) override;
+
+  void update(mc_control::MCController & ctl) override;
+
+protected:
+  /// @brief sets all the covariances required by the Kinetics Observer
+  void setObserverCovariances();
+  /// @brief Update the pose and velocities of the robot in the world frame. Used only to update the ones of the robot
+  /// used for the visualization of the estimation made by the Kinetics Observer.
+  /// @param robot The robot to update.
+  void update(mc_rbdyn::Robot & robot);
+
+  /// @brief Initializer for the Kinetics Observer's state vector
+  /// @param robot The control robot
+  void initObserverStateVector(const mc_rbdyn::Robot & robot);
+
+  /// @brief Sums up the wrenches measured by the unused force sensors expressed in the centroid frame to give them as
+  /// an input to the Kinetics Observer
+  /// @param inputRobot A robot whose configuration is the one of real robot, but whose pose, velocities and
+  /// accelerations are set to zero in the control frame. Allows to ease computations performed in the local frame of
+  /// the robot.
+  /// @param measRobot The control robot. Used to retrieve the measurements.
+  void inputAdditionalWrench(const mc_rbdyn::Robot & inputRobot, const mc_rbdyn::Robot & measRobot);
+
+  /// @brief Adds the measurement of the desired sensors to the external force given as an input to the Kinetics
+  /// Observer
+  /// @details The force sensors must be given with the list forceSensorsAsInput_
+  /// @param inputRobot A robot whose configuration is the one of real robot, but whose pose, velocities and
+  /// accelerations are set to zero in the control frame. Allows to ease computations performed in the local frame of
+  /// the robot.
+  /// @param measRobot The control robot. Used to retrieve the measurements.
+  /// @param inputAddtionalForce the external force given as input
+  /// @param inputAddtionalTorque the external torque given as input
+  void addSensorsAsInputs(const mc_rbdyn::Robot & inputRobot,
+                          const mc_rbdyn::Robot & measRobot,
+                          stateObservation::Vector3 & inputAddtionalForce,
+                          stateObservation::Vector3 & inputAddtionalTorque);
+
+  /// @brief Update the IMUs, including the measurements, measurement covariances and kinematics in the floating
+  /// base's frame (user frame)
+  /// @param measRobot The control robot
+  /// @param inputRobot A robot whose configuration is the one of real robot, but whose pose, velocities and
+  /// accelerations are set to zero in the control frame. Allows to ease computations performed in the local frame of
+  /// the robot.
+  void updateIMUs(const mc_rbdyn::Robot & measRobot, const mc_rbdyn::Robot & inputRobot);
+
+  /*! \brief Add observer from logger
+   *
+   * @param category Category in which to log this observer
+   */
+
+  /// @brief Add the logs of the desired contact.
+  /// @param contactIndex The index of the contact.
+  /// @param logger
+  void addContactLogEntries(mc_rtc::Logger & logger, const int & contactIndex);
+  /// @brief Remove the logs of the desired contact.
+  /// @param contactIndex The index of the contact.
+  /// @param logger
+  void removeContactLogEntries(mc_rtc::Logger & logger, const int & contactIndex);
+
+  /// @brief Add the measurements logs of the desired contact.
+  /// @param contactIndex The index of the contact.
+  /// @param logger
+  void addContactMeasurementsLogEntries(mc_rtc::Logger & logger, const int & contactIndex);
+  /// @brief Remove the measurements logs of the desired contact.
+  /// @param contactIndex The index of the contact.
+  /// @param logger
+  void removeContactMeasurementsLogEntries(mc_rtc::Logger & logger, const int & contactIndex);
+
+  void addToLogger(const mc_control::MCController &, mc_rtc::Logger &, const std::string & category) override;
+
+  /*! \brief Remove observer from logger
+   *
+   * @param category Category in which this observer entries are logged
+   */
+  void removeFromLogger(mc_rtc::Logger &, const std::string & category) override;
+
+  /*! \brief Add observer information the GUI.
+   *
+   * @param category Category in which to add this observer
+   */
+  void addToGUI(const mc_control::MCController &,
+                mc_rtc::gui::StateBuilder &,
+                const std::vector<std::string> & /* category */) override;
+
+  /// @brief Changes the type of the odometry
+  /// @param ctl Controller.
+  /// @param newOdometryType The new type of odometry to use.
+  void changeOdometryType(const mc_control::MCController & ctl, const std::string & newOdometryType);
+
+protected:
+  /// @brief Updates the list of currently set contacts.
+  /// @return measurements::ContactsManager<measurements::ContactWithSensor,
+  /// measurements::ContactWithoutSensor>::ContactsSet &
+  const measurements::ContactsManager<KoContactWithSensor, measurements::ContactWithoutSensor>::ContactsSet &
+      findNewContacts(const mc_control::MCController & ctl);
+
+  /// @brief Update the currently set contacts.
+  /// @details The list of contacts is returned by \ref findNewContacts(const mc_control::MCController & ctl). Calls
+  /// \ref updateContact(const mc_control::MCController & ctl, const std::string & name, mc_rtc::Logger & logger).
+  /// @param contacts The list of contacts returned by \ref findNewContacts(const mc_control::MCController & ctl).
+  void updateContacts(const mc_control::MCController & ctl,
+                      const measurements::ContactsManager<KoContactWithSensor,
+                                                          measurements::ContactWithoutSensor>::ContactsSet & contacts,
+                      mc_rtc::Logger & logger);
+
+  /// @brief Computes the kinematics of the contact attached to the robot in the world frame. Also expresses the wrench
+  /// measured at the sensor in the frame of the contact.
+  /// @param contact Contact of which we want to compute the kinematics
+  /// @param robot robot the contacts belong to
+  /// @param fs force sensor
+  /// @param measuredWrench wrench measured at the sensor
+  /// @return stateObservation::kine::Kinematics &
+  const stateObservation::kine::Kinematics getContactWorldKinematicsAndWrench(KoContactWithSensor & contact,
+                                                                              const mc_rbdyn::Robot & robot,
+                                                                              const mc_rbdyn::ForceSensor & fs,
+                                                                              const sva::ForceVecd & measuredWrench);
+
+  /// @brief Computes the kinematics of the contact attached to the robot in the world frame.
+  /// @param contact Contact of which we want to compute the kinematics
+  /// @param robot robot the contacts belong to
+  /// @param fs force sensor
+  /// @return stateObservation::kine::Kinematics &
+  const stateObservation::kine::Kinematics getContactWorldKinematics(KoContactWithSensor & contact,
+                                                                     const mc_rbdyn::Robot & robot,
+                                                                     const mc_rbdyn::ForceSensor & fs);
+
+  /// @brief Updates the measurements of the force sensor attached to a contact.
+  /// @details Expresses the measured wrench in the frame of the contact, as the sensor is not necessarily attached to
+  /// it.
+  /// @param contact Contact associated to the sensor
+  /// @param surfaceSensorKine transformation from the sensor to the contact.
+  /// @param measuredWrench measured wrench
+  void updateContactForceMeasurement(KoContactWithSensor & contact,
+                                     stateObservation::kine::Kinematics surfaceSensorKine,
+                                     const sva::ForceVecd & measuredWrench);
+
+  /// @brief Updates the measurements of the force sensor attached to a contact.
+  /// @details Expresses the measured wrench in the frame of the contact, as the sensor is not necessarily attached to
+  /// it.
+  /// @param contact Contact associated to the sensor
+  /// @param surfaceSensorKine transformation from the sensor to the contact.
+  /// @param measuredWrench measured wrench
+  void updateContactForceMeasurement(KoContactWithSensor & contact, const sva::ForceVecd & measuredWrench);
+
+  /// @brief Computes the rest pose of the contact in the world using the visco-elastic model.
+  /// @details Uses the measured wrench to obtain the rest pose of the contact from the one obtained by forward
+  /// kinematics. The visco-elastic model allows to compute the slight displacement resulting from the applied wrench.
+  /// @param ctl Controller
+  /// @param contact Contact for which we compute the rest pose.
+  /// @param worldContactKineRef rest pose of the contact in the world, which is modified by this function.
+  void getOdometryWorldContactRest(const mc_control::MCController & ctl,
+                                   KoContactWithSensor & contact,
+                                   stateObservation::kine::Kinematics & worldContactKineRef);
+
+  /// @brief Update the contact or create it if it still does not exist.
+  /// @details Called by \ref updateContacts(const mc_control::MCController & ctl, std::set<std::string> contacts,
+  /// mc_rtc::Logger & logger).
+  /// @param name The name of the contact to update.
+  void updateContact(const mc_control::MCController & ctl, const int & contactIndex, mc_rtc::Logger & logger);
+
+public:
+  /** Get robot mass.
+   *
+   */
+  inline double mass() const { return mass_; }
+
+  /** Set robot mass.
+   *
+   * \param mass Robot mass.
+   *
+   */
+  void mass(double mass);
+
+  /** Set stiffness of the robot-environment flexibility.
+   *
+   * \param stiffness Flexibility stiffness.
+   *
+   */
+  void flexStiffness(const sva::MotionVecd & stiffness);
+
+  /** Set damping of the robot-environment flexibility.
+   *
+   * \param damping Flexibility damping.
+   *
+   */
+  void flexDamping(const sva::MotionVecd & damping);
+
+  /** Update measurement-noise covariance matrix.
+   *
+   */
+  void updateNoiseCovariance();
+
+  /** Get accelerometer measurement noise covariance.
+   *
+   */
+  inline double accelNoiseCovariance() const { return acceleroSensorCovariance_(0, 0); }
+
+  /** Change accelerometer measurement noise covariance.
+   *
+   * \param covariance New covariance.
+   *
+   */
+  inline void accelNoiseCovariance(double covariance)
+  {
+    acceleroSensorCovariance_ = stateObservation::Matrix3::Identity() * covariance;
+    updateNoiseCovariance();
+  }
+
+  /** Set debug flag.
+   *
+   * \param flag New debug flag.
+   *
+   */
+  inline void debug(bool flag) { debug_ = flag; }
+
+  /** Get force-sensor measurement noise covariance.
+   *
+   */
+  inline double forceSensorNoiseCovariance() const { return contactSensorCovariance_(0, 0); }
+
+  /** Change force-sensor measurement noise covariance.
+   *
+   * \param covariance New covariance.
+   *
+   */
+  inline void forceSensorNoiseCovariance(double covariance)
+  {
+    contactSensorCovariance_.block<3, 3>(0, 0) = stateObservation::Matrix3::Identity() * covariance;
+    updateNoiseCovariance();
+  }
+
+  /** Get gyrometer measurement noise covariance.
+   *
+   */
+  inline double gyroNoiseCovariance() const { return gyroSensorCovariance_(0, 0); }
+
+  /** Change gyrometer measurement noise covariance.
+   *
+   * \param covariance New covariance.
+   *
+   */
+  inline void gyroNoiseCovariance(double covariance)
+  {
+    gyroSensorCovariance_ = stateObservation::Matrix3::Identity() * covariance;
+    updateNoiseCovariance();
+  }
+
+  /** Get last measurement vector sent to observer.
+   *
+   */
+  inline const Eigen::VectorXd measurements() const { return observer_.getEKF().getLastMeasurement(); }
+
+  /** Floating-base transform estimate.
+   *
+   */
+  inline const sva::PTransformd & posW() const { return X_0_fb_; }
+
+  /** Floating-base velocity estimate.
+   *
+   */
+  inline const sva::MotionVecd & velW() const { return v_fb_0_; }
+
+private:
+  enum EstimationState
+  {
+    noIssue,
+    errorDetected,
+    invincibilityFrame
+  };
+
+  // indicates if the current iteration encountered no issue, encountered one, or is inside the invincibility frame
+  // (recovery frame after an error)
+  EstimationState estimationState_;
+
+  // instance of the Kinetics Observer
+  stateObservation::KineticsObserver observer_;
+  // name of the estimator
+  std::string observerName_ = "MCKineticsObserver";
+  // name of the robot
+  std::string robot_ = "";
+  /* custom list of robots to display */
+  std::shared_ptr<mc_rbdyn::Robots> my_robots_;
+  // std::string imuSensor_ = "";
+  mc_rbdyn::BodySensorVector IMUs_; ///< list of IMUs
+
+  /* Estimation parameters */
+  bool debug_ = false;
+  bool verbose_ = true;
+
+  /* Estimation results */
+
+  // state vector resulting from the Kinetics Observer esimation
+  Eigen::VectorXd res_;
+  // pose of the floating base within the world frame (real one, not the one of the control robot)
+  sva::PTransformd X_0_fb_;
+  // velocity of the floating base within the world frame (real one, not the one of the control robot)
+  sva::MotionVecd v_fb_0_;
+  // acceleration of the floating base within the world frame (real one, not the one of the control robot)
+  sva::MotionVecd a_fb_0_;
+
+  /* Settings of the Kinetics Observers */
+  // mass of the robot
+  double mass_ = 42; // [kg]
+  // maximum amount of contacts that we want to use with the Kinetics Observer.
+  int maxContacts_ = 4;
+  // maximum amount of IMUs that we want to use with the Kinetics Observer.
+  int maxIMUs_ = 2;
+
+  // linear stiffness of contacts
+  stateObservation::Matrix3 linStiffness_;
+  // linear damping of contacts
+  stateObservation::Matrix3 linDamping_;
+  // angular stiffness of contacts
+  stateObservation::Matrix3 angStiffness_;
+  // linear damping of contacts
+  stateObservation::Matrix3 angDamping_;
+
+  // indicates if the debug logs have to be added.
+  bool withDebugLogs_ = true;
+  // indicates if we want to perform odometry, and if yes, flat or 6d odometry
+  using OdometryType = measurements::OdometryType;
+  OdometryType odometryType_;
+  // indicates if we want to estimate the unmodeled wrench within the Kinetics Observer.
+  bool withUnmodeledWrench_ = true;
+  // indicates if we want to estimate the bias on the gyrometer measurement within the Kinetics Observer.
+  bool withGyroBias_ = true;
+
+  /* Kalman Filter's covariances */
+
+  // initial covariance on the position estimate
+  stateObservation::Matrix3 statePositionInitCovariance_;
+  // initial covariance on the orientation estimate
+  stateObservation::Matrix3 stateOriInitCovariance_;
+  // initial covariance on the local linear velocity estimate
+  stateObservation::Matrix3 stateLinVelInitCovariance_;
+  // initial covariance on the local angular velocity estimate
+  stateObservation::Matrix3 stateAngVelInitCovariance_;
+  // initial covariance on the gyrometer bias estimate
+  stateObservation::Matrix3 gyroBiasInitCovariance_;
+  // initial covariance on the unmodeled wrench estimate
+  stateObservation::Matrix6 unmodeledWrenchInitCovariance_;
+  // initial covariance on the contact rest pose estimate, when no other contact is currently set
+  stateObservation::Matrix12 contactInitCovarianceFirstContacts_;
+  // initial covariance on the contact rest pose estimate, when other contacts are currently set
+  stateObservation::Matrix12 contactInitCovarianceNewContacts_;
+
+  // covariance on the position's state transition
+  stateObservation::Matrix3 statePositionProcessCovariance_;
+  // covariance on the orientation's state transition
+  stateObservation::Matrix3 stateOriProcessCovariance_;
+  // covariance on the local linear velocity's state transition
+  stateObservation::Matrix3 stateLinVelProcessCovariance_;
+  // covariance on the angular velocity's state transition
+  stateObservation::Matrix3 stateAngVelProcessCovariance_;
+  // covariance on the gyrometer bias' state transition
+  stateObservation::Matrix3 gyroBiasProcessCovariance_;
+  // covariance on the unmodeled wrench's state transition
+  stateObservation::Matrix6 unmodeledWrenchProcessCovariance_;
+  // covariance on the contact rest pose's state transition
+  stateObservation::Matrix12 contactProcessCovariance_;
+
+  // covariance on the absolute position measurement
+  stateObservation::Matrix3 positionSensorCovariance_;
+  // covariance on the absolute orientation measurement
+  stateObservation::Matrix3 orientationSensorCoVariance_;
+  // covariance on the accelerometer measurement
+  stateObservation::Matrix3 acceleroSensorCovariance_;
+  // covariance on the gyrometer measurement
+  stateObservation::Matrix3 gyroSensorCovariance_;
+  // covariance on the contact's force sensors measurement
+  stateObservation::Matrix6 contactSensorCovariance_;
+  // covariance on the gyrometer measurement
+  stateObservation::Matrix3 absoluteOriSensorCovariance_;
+
+  /* Contacts manager variables */
+  using KoContactsManager = measurements::ContactsManager<KoContactWithSensor, measurements::ContactWithoutSensor>;
+  KoContactsManager contactsManager_;
+  // indicates if the forces measurement have to be filtered with a low-pass filter.
+  bool withFilteredForcesContactDetection_ = false;
+  // threshold on the measured force for contact detection.
+  double contactDetectionThreshold_ = 0.0;
+  // list of the force sensors that cannot be used with contacts but we want to use their measurements as inputs to the
+  // Kinetics Observer
+  std::vector<std::string> forceSensorsAsInput_ = std::vector<std::string>();
+
+  /* IMU variables */
+  // manager for the IMUs
+  measurements::MapIMUs mapIMUs_;
+
+  /* Utilitary variables */
+  // zero frame transformation
+  sva::PTransformd zeroPose_;
+  // zero velocity or acceleration
+  sva::MotionVecd zeroMotion_;
+  // kinematics of the CoM within the world frame of the input robot
+  stateObservation::kine::Kinematics worldCoMKine_;
+  /**< grouped inertia */
+  sva::RBInertiad inertiaWaist_;
+  // total force measured by the sensors that are not associated to a currently set contact and expressed in the
+  // floating base's frame. Used as an input for the Kinetics Observer.
+  stateObservation::Vector3 additionalUserResultingForce_ = stateObservation::Vector3::Zero();
+  // total torque measured by the sensors that are not associated to a currently set contact and expressed in the
+  // floating base's frame. Used as an input for the Kinetics Observer.
+  stateObservation::Vector3 additionalUserResultingMoment_ = stateObservation::Vector3::Zero();
+
+  /* Variables for the backup */
+  // iteration on which the backup was required for the last time
+  int lastBackupIter_;
+  // number of iterations on which we perform the backup
+  int backupIterInterval_ = 0;
+  // time during which the Kinetics Observer is still getting updated by the Tilt Observer after the need of a backup,
+  // so the Kalman Filter has time to converge again
+  int invincibilityFrame_ = 0;
+  // iterations ellapsed within the invincibility frame
+  int invincibilityIter_;
+
+  // Buffer containing the estimated pose of the floating base in the world over the whole backup interval.
+  boost::circular_buffer<stateObservation::kine::Kinematics> koBackupFbKinematics_;
+
+  /* Debug variables */
+  // For logs only. Prediction of the measurements from the newly corrected state
+  stateObservation::Vector correctedMeasurements_;
+  // For logs only. Kinematics of the centroid frame within the world frame
+  stateObservation::kine::Kinematics globalCentroidKinematics_;
+};
+
+} // namespace mc_state_observation

--- a/include/mc_state_observation/MCKineticsObserver.h
+++ b/include/mc_state_observation/MCKineticsObserver.h
@@ -130,6 +130,8 @@ protected:
                 mc_rtc::gui::StateBuilder &,
                 const std::vector<std::string> & /* category */) override;
 
+  void addContactToGui(const mc_control::MCController & ctl, KoContactWithSensor & contact);
+
   /// @brief Sets the type of the odometry
   /// @param newOdometryType The new type of odometry to use.
   void setOdometryType(const std::string & newOdometryType);

--- a/include/mc_state_observation/MCKineticsObserver.h
+++ b/include/mc_state_observation/MCKineticsObserver.h
@@ -443,7 +443,7 @@ private:
 
   /* IMU variables */
   // manager for the IMUs
-  measurements::MapIMUs mapIMUs_;
+  measurements::ImuList listIMUs_;
 
   /* Utilitary variables */
   // zero frame transformation

--- a/include/mc_state_observation/MCKineticsObserver.h
+++ b/include/mc_state_observation/MCKineticsObserver.h
@@ -112,22 +112,25 @@ protected:
    */
 
   /// @brief Add the logs of the desired contact.
-  /// @param contactIndex The index of the contact.
+  /// @param Controller Controller
+  /// @param contact contact
   /// @param logger
-  void addContactLogEntries(mc_rtc::Logger & logger, const int & contactIndex);
+  void addContactLogEntries(const mc_control::MCController & ctl,
+                            mc_rtc::Logger & logger,
+                            const KoContactWithSensor & contact);
   /// @brief Remove the logs of the desired contact.
-  /// @param contactIndex The index of the contact.
+  /// @param contact Contact
   /// @param logger
-  void removeContactLogEntries(mc_rtc::Logger & logger, const int & contactIndex);
+  void removeContactLogEntries(mc_rtc::Logger & logger, const KoContactWithSensor & contact);
 
   /// @brief Add the measurements logs of the desired contact.
-  /// @param contactIndex The index of the contact.
+  /// @param contact Contact
   /// @param logger
-  void addContactMeasurementsLogEntries(mc_rtc::Logger & logger, const int & contactIndex);
+  void addContactMeasurementsLogEntries(mc_rtc::Logger & logger, const KoContactWithSensor & contact);
   /// @brief Remove the measurements logs of the desired contact.
-  /// @param contactIndex The index of the contact.
+  /// @param contact Contact
   /// @param logger
-  void removeContactMeasurementsLogEntries(mc_rtc::Logger & logger, const int & contactIndex);
+  void removeContactMeasurementsLogEntries(mc_rtc::Logger & logger, const KoContactWithSensor & contact);
 
   void addToLogger(const mc_control::MCController &, mc_rtc::Logger &, const std::string & category) override;
 
@@ -174,7 +177,7 @@ protected:
   /// @param robot robot the contacts belong to
   /// @param fs force sensor
   /// @return stateObservation::kine::Kinematics &
-  const stateObservation::kine::Kinematics getContactWorldKinematics(KoContactWithSensor & contact,
+  const stateObservation::kine::Kinematics getContactWorldKinematics(const KoContactWithSensor & contact,
                                                                      const mc_rbdyn::Robot & robot,
                                                                      const mc_rbdyn::ForceSensor & fs);
 

--- a/include/mc_state_observation/MCKineticsObserver.h
+++ b/include/mc_state_observation/MCKineticsObserver.h
@@ -28,17 +28,7 @@ namespace mc_state_observation
 /// floating base and the kinematics of the frame of the sensor in the frame of the contact surface
 struct KoContactWithSensor : public measurements::ContactWithSensor
 {
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-protected:
-  KoContactWithSensor() {}
-
-public:
-  KoContactWithSensor(int id, std::string forceSensorName) : measurements::ContactWithSensor(id, forceSensorName) {}
-
-  KoContactWithSensor(int id, const std::string & forceSensorName, const std::string & surfaceName)
-  : measurements::ContactWithSensor(id, forceSensorName, surfaceName)
-  {
-  }
+  using measurements::ContactWithSensor::ContactWithSensor;
 
 public:
   // kinematics of the contact frame in the floating base's frame

--- a/include/mc_state_observation/MCKineticsObserver.h
+++ b/include/mc_state_observation/MCKineticsObserver.h
@@ -5,7 +5,8 @@
 #include <mc_rbdyn/Contact.h>
 #include <mc_rbdyn/Robot.h>
 #include <boost/circular_buffer.hpp>
-#include <mc_state_observation/measurements/measurementsTools.h>
+#include <mc_state_observation/measurements/ContactsManager.h>
+#include <mc_state_observation/measurements/measurements.h>
 #include <state-observation/dynamics-estimators/kinetics-observer.hpp>
 
 #include <mc_observers/Observer.h>

--- a/include/mc_state_observation/MCKineticsObserver.h
+++ b/include/mc_state_observation/MCKineticsObserver.h
@@ -5,7 +5,7 @@
 #include <mc_rbdyn/Contact.h>
 #include <mc_rbdyn/Robot.h>
 #include <boost/circular_buffer.hpp>
-#include <mc_state_observation/observersTools/measurementsTools.h>
+#include <mc_state_observation/measurements/measurementsTools.h>
 #include <state-observation/dynamics-estimators/kinetics-observer.hpp>
 
 #include <mc_observers/Observer.h>
@@ -33,27 +33,11 @@ protected:
   KoContactWithSensor() {}
 
 public:
-  KoContactWithSensor(int id, std::string forceSensorName)
+  KoContactWithSensor(int id, std::string forceSensorName) : measurements::ContactWithSensor(id, forceSensorName) {}
+
+  KoContactWithSensor(int id, const std::string & forceSensorName, const std::string & surfaceName)
+  : measurements::ContactWithSensor(id, forceSensorName, surfaceName)
   {
-    id_ = id;
-    name_ = forceSensorName;
-    forceSensorName_ = forceSensorName;
-
-    resetContact();
-  }
-
-  KoContactWithSensor(int id,
-                      const std::string & forceSensorName,
-                      const std::string & surfaceName,
-                      bool sensorAttachedToSurface)
-  {
-    id_ = id;
-    name_ = forceSensorName;
-    resetContact();
-
-    surface_ = surfaceName;
-    forceSensorName_ = forceSensorName;
-    sensorAttachedToSurface_ = sensorAttachedToSurface;
   }
 
 public:
@@ -166,16 +150,15 @@ protected:
   /// @brief Updates the list of currently set contacts.
   /// @return measurements::ContactsManager<measurements::ContactWithSensor,
   /// measurements::ContactWithoutSensor>::ContactsSet &
-  const measurements::ContactsManager<KoContactWithSensor, measurements::ContactWithoutSensor>::ContactsSet &
-      findNewContacts(const mc_control::MCController & ctl);
+  const measurements::ContactsManager<KoContactWithSensor>::ContactsSet & findNewContacts(
+      const mc_control::MCController & ctl);
 
   /// @brief Update the currently set contacts.
   /// @details The list of contacts is returned by \ref findNewContacts(const mc_control::MCController & ctl). Calls
   /// \ref updateContact(const mc_control::MCController & ctl, const std::string & name, mc_rtc::Logger & logger).
   /// @param contacts The list of contacts returned by \ref findNewContacts(const mc_control::MCController & ctl).
   void updateContacts(const mc_control::MCController & ctl,
-                      const measurements::ContactsManager<KoContactWithSensor,
-                                                          measurements::ContactWithoutSensor>::ContactsSet & contacts,
+                      const measurements::ContactsManager<KoContactWithSensor>::ContactsSet & contacts,
                       mc_rtc::Logger & logger);
 
   /// @brief Computes the kinematics of the contact attached to the robot in the world frame. Also expresses the wrench
@@ -448,7 +431,7 @@ private:
   stateObservation::Matrix3 absoluteOriSensorCovariance_;
 
   /* Contacts manager variables */
-  using KoContactsManager = measurements::ContactsManager<KoContactWithSensor, measurements::ContactWithoutSensor>;
+  using KoContactsManager = measurements::ContactsManager<KoContactWithSensor>;
   KoContactsManager contactsManager_;
   // indicates if the forces measurement have to be filtered with a low-pass filter.
   bool withFilteredForcesContactDetection_ = false;

--- a/include/mc_state_observation/MCKineticsObserver.h
+++ b/include/mc_state_observation/MCKineticsObserver.h
@@ -424,8 +424,6 @@ private:
   /* Contacts manager variables */
   using KoContactsManager = measurements::ContactsManager<KoContactWithSensor>;
   KoContactsManager contactsManager_;
-  // indicates if the forces measurement have to be filtered with a low-pass filter.
-  bool withFilteredForcesContactDetection_ = false;
   // threshold on the measured force for contact detection.
   double contactDetectionThreshold_ = 0.0;
   // list of the force sensors that cannot be used with contacts but we want to use their measurements as inputs to the

--- a/include/mc_state_observation/MCKineticsObserver.h
+++ b/include/mc_state_observation/MCKineticsObserver.h
@@ -2,14 +2,11 @@
 
 #pragma once
 
-#include <mc_rbdyn/Contact.h>
-#include <mc_rbdyn/Robot.h>
 #include <boost/circular_buffer.hpp>
+
 #include <mc_state_observation/measurements/ContactsManager.h>
 #include <mc_state_observation/measurements/measurements.h>
 #include <state-observation/dynamics-estimators/kinetics-observer.hpp>
-
-#include <mc_observers/Observer.h>
 
 namespace mc_state_observation
 {

--- a/include/mc_state_observation/MCKineticsObserver.h
+++ b/include/mc_state_observation/MCKineticsObserver.h
@@ -130,9 +130,8 @@ protected:
                 const std::vector<std::string> & /* category */) override;
 
   /// @brief Sets the type of the odometry
-  /// @param ctl Controller.
   /// @param newOdometryType The new type of odometry to use.
-  void setOdometryType(const mc_control::MCController & ctl, const std::string & newOdometryType);
+  void setOdometryType(const std::string & newOdometryType);
 
 protected:
   /// @brief Updates the list of currently set contacts.
@@ -363,9 +362,12 @@ private:
 
   // indicates if the debug logs have to be added.
   bool withDebugLogs_ = true;
+
   // indicates if we want to perform odometry, and if yes, flat or 6d odometry
-  using OdometryType = measurements::OdometryType;
-  OdometryType odometryType_;
+  measurements::OdometryType odometryType_;
+  // odometry method used on last iteration. Used to check if it changed in order to apply the change to the Tilt
+  // Observer if necessary.
+  measurements::OdometryType prevOdometryType_;
   // indicates if we want to estimate the unmodeled wrench within the Kinetics Observer.
   bool withUnmodeledWrench_ = true;
   // indicates if we want to estimate the bias on the gyrometer measurement within the Kinetics Observer.

--- a/include/mc_state_observation/MCKineticsObserver.h
+++ b/include/mc_state_observation/MCKineticsObserver.h
@@ -4,6 +4,7 @@
 
 #include <boost/circular_buffer.hpp>
 
+#include "mc_state_observation/TiltObserver.h"
 #include <mc_state_observation/measurements/ContactsManager.h>
 #include <mc_state_observation/measurements/measurements.h>
 #include <state-observation/dynamics-estimators/kinetics-observer.hpp>
@@ -306,6 +307,11 @@ public:
   inline const sva::MotionVecd & velW() const { return v_fb_0_; }
 
 private:
+  // instance of the Kinetics Observer
+  stateObservation::KineticsObserver observer_;
+  // instance of the Tilt Observer used as a backup
+  TiltObserver tiltObserver_;
+
   enum EstimationState
   {
     noIssue,
@@ -317,8 +323,6 @@ private:
   // (recovery frame after an error)
   EstimationState estimationState_;
 
-  // instance of the Kinetics Observer
-  stateObservation::KineticsObserver observer_;
   // name of the estimator
   std::string observerName_ = "MCKineticsObserver";
   // name of the robot

--- a/include/mc_state_observation/MCKineticsObserver.h
+++ b/include/mc_state_observation/MCKineticsObserver.h
@@ -44,7 +44,10 @@ public:
   Eigen::Matrix<double, 6, 1> contactWrenchVector_;
   // contact wrench expressed in the centroid frame. Used for logs.
   Eigen::Matrix<double, 6, 1> wrenchInCentroid_ = Eigen::Matrix<double, 6, 1>::Zero();
-  // allows to know if the contact's measurements have to be added during the update.
+
+  // the sensor measurement has to be used by the observer
+  bool sensorEnabled_ = true;
+  // allows to know if the logs related to the contact's measurements have to be added.
   bool sensorWasEnabled_ = false;
 };
 

--- a/include/mc_state_observation/MCKineticsObserver.h
+++ b/include/mc_state_observation/MCKineticsObserver.h
@@ -141,10 +141,10 @@ protected:
                 mc_rtc::gui::StateBuilder &,
                 const std::vector<std::string> & /* category */) override;
 
-  /// @brief Changes the type of the odometry
+  /// @brief Sets the type of the odometry
   /// @param ctl Controller.
   /// @param newOdometryType The new type of odometry to use.
-  void changeOdometryType(const mc_control::MCController & ctl, const std::string & newOdometryType);
+  void setOdometryType(const mc_control::MCController & ctl, const std::string & newOdometryType);
 
 protected:
   /// @brief Updates the list of currently set contacts.

--- a/include/mc_state_observation/MCKineticsObserver.h
+++ b/include/mc_state_observation/MCKineticsObserver.h
@@ -29,11 +29,23 @@ struct KoContactWithSensor : public measurements::ContactWithSensor
 {
   using measurements::ContactWithSensor::ContactWithSensor;
 
+  inline void resetContact() noexcept
+  {
+    ContactWithSensor::resetContact();
+    sensorWasEnabled_ = false;
+  }
+
 public:
   // kinematics of the contact frame in the floating base's frame
   stateObservation::kine::Kinematics fbContactKine_;
   // kinematics of the sensor frame in the frame of the contact surface
   stateObservation::kine::Kinematics surfaceSensorKine_;
+  // measured contact wrench, expressed in the frame of the contact.
+  Eigen::Matrix<double, 6, 1> contactWrenchVector_;
+  // contact wrench expressed in the centroid frame. Used for logs.
+  Eigen::Matrix<double, 6, 1> wrenchInCentroid_ = Eigen::Matrix<double, 6, 1>::Zero();
+  // allows to know if the contact's measurements have to be added during the update.
+  bool sensorWasEnabled_ = false;
 };
 
 struct MCKineticsObserver : public mc_observers::Observer

--- a/include/mc_state_observation/MCKineticsObserver.h
+++ b/include/mc_state_observation/MCKineticsObserver.h
@@ -137,19 +137,10 @@ protected:
   void setOdometryType(const std::string & newOdometryType);
 
 protected:
-  /// @brief Updates the list of currently set contacts.
-  /// @return measurements::ContactsManager<measurements::ContactWithSensor,
-  /// measurements::ContactWithoutSensor>::ContactsSet &
-  const measurements::ContactsManager<KoContactWithSensor>::ContactsSet & findNewContacts(
-      const mc_control::MCController & ctl);
-
   /// @brief Update the currently set contacts.
-  /// @details The list of contacts is returned by \ref findNewContacts(const mc_control::MCController & ctl). Calls
-  /// \ref updateContact(const mc_control::MCController & ctl, const std::string & name, mc_rtc::Logger & logger).
-  /// @param contacts The list of contacts returned by \ref findNewContacts(const mc_control::MCController & ctl).
-  void updateContacts(const mc_control::MCController & ctl,
-                      const measurements::ContactsManager<KoContactWithSensor>::ContactsSet & contacts,
-                      mc_rtc::Logger & logger);
+  /// @param ctl Controller
+  /// @param logger Logger
+  void updateContacts(const mc_control::MCController & ctl, mc_rtc::Logger & logger);
 
   /// @brief Computes the kinematics of the contact attached to the robot in the world frame. Also expresses the wrench
   /// measured at the sensor in the frame of the contact.
@@ -200,11 +191,17 @@ protected:
                                    KoContactWithSensor & contact,
                                    stateObservation::kine::Kinematics & worldContactKineRef);
 
-  /// @brief Update the contact or create it if it still does not exist.
-  /// @details Called by \ref updateContacts(const mc_control::MCController & ctl, std::set<std::string> contacts,
-  /// mc_rtc::Logger & logger).
-  /// @param name The name of the contact to update.
-  void updateContact(const mc_control::MCController & ctl, const int & contactIndex, mc_rtc::Logger & logger);
+  /// @brief Creates a new contact
+  /// @param ctl Controller
+  /// @param contact Contact to update
+  /// @param logger Logger
+  void setNewContact(const mc_control::MCController & ctl, KoContactWithSensor & contact, mc_rtc::Logger & logger);
+
+  /// @brief Updates an already set contact
+  /// @param ctl Controller
+  /// @param contact Contact to update
+  /// @param logger Logger
+  void updateContact(const mc_control::MCController & ctl, KoContactWithSensor & contact, mc_rtc::Logger & logger);
 
 public:
   /** Get robot mass.

--- a/include/mc_state_observation/NaiveOdometry.h
+++ b/include/mc_state_observation/NaiveOdometry.h
@@ -1,0 +1,135 @@
+/* Copyright 2017-2020 CNRS-AIST JRL, CNRS-UM LIRMM */
+
+#pragma once
+
+#include <mc_rbdyn/Contact.h>
+#include <mc_rbdyn/Robot.h>
+
+#include <mc_state_observation/observersTools/leggedOdometryTools.h>
+#include <state-observation/dynamics-estimators/kinetics-observer.hpp>
+
+#include <mc_observers/Observer.h>
+
+namespace mc_state_observation
+{
+namespace so = stateObservation;
+
+struct NaiveOdometry : public mc_observers::Observer
+{
+
+  NaiveOdometry(const std::string & type, double dt);
+
+  void configure(const mc_control::MCController & ctl, const mc_rtc::Configuration &) override;
+
+  void reset(const mc_control::MCController & ctl) override;
+
+  bool run(const mc_control::MCController & ctl) override;
+
+  void update(mc_control::MCController & ctl) override;
+
+protected:
+  void update(mc_rbdyn::Robot & robot);
+
+  /*! \brief Add observer from logger
+   *
+   * @param category Category in which to log this observer
+   */
+
+  void plotVariablesBeforeUpdate(const mc_control::MCController & ctl, mc_rtc::Logger & logger);
+
+  void plotVariablesAfterUpdate(const mc_control::MCController & ctl, mc_rtc::Logger & logger);
+
+  void addToLogger(const mc_control::MCController &, mc_rtc::Logger &, const std::string & category) override;
+
+  void addContactLogEntries(mc_rtc::Logger & logger, const std::string & contactName);
+
+  void removeContactLogEntries(mc_rtc::Logger & logger, const std::string & contactName);
+
+  /*! \brief Remove observer from logger
+   *
+   * @param category Category in which this observer entries are logged
+   */
+  void removeFromLogger(mc_rtc::Logger &, const std::string & category) override;
+
+  /*! \brief Add observer information the GUI.
+   *
+   * @param category Category in which to add this observer
+   */
+  void addToGUI(const mc_control::MCController &,
+                mc_rtc::gui::StateBuilder &,
+                const std::vector<std::string> & /* category */) override;
+
+protected:
+  /**
+   * Find established contacts between the observed robot and the fixed robots
+   *
+   * \param ctl Controller that defines the contacts
+   * \return Name of surfaces in contact with the environment
+   */
+
+  /*
+    void updateContacts(const mc_control::MCController & ctl,
+                        mc_rbdyn::Robot & odometryRobot,
+                        std::set<std::string> contacts,
+                        mc_rtc::Logger & logger);
+
+    void setNewContact(const mc_rbdyn::Robot & odometryRobot, const mc_rbdyn::ForceSensor forceSensor);
+  */
+protected:
+  std::string robot_ = "";
+  // std::string imuSensor_ = "";
+  mc_rbdyn::BodySensorVector IMUs_; ///< list of IMUs
+
+public:
+  /** Get robot mass.
+   *
+   */
+  inline double mass() const { return mass_; }
+
+  /** Set robot mass.
+   *
+   * \param mass Robot mass.
+   *
+   */
+  void mass(double mass);
+
+  /** Set stiffness of the robot-environment flexibility.
+   *
+   * \param stiffness Flexibility stiffness.
+   *
+   */
+
+  /** Floating-base transform estimate.
+   *
+   */
+  inline const sva::PTransformd & posW() const { return X_0_fb_; }
+
+  /** Floating-base velocity estimate.
+   *
+   */
+  inline const sva::MotionVecd & velW() const { return v_fb_0_; }
+
+private:
+  std::string category_ = "NaiveOdometry_";
+  /* custom list of robots to display */
+  std::shared_ptr<mc_rbdyn::Robots> my_robots_;
+
+  // threshold on the force for the contact detection.
+  double contactDetectionThreshold_;
+
+  double mass_ = 42; // [kg]
+  // std::set<std::string> contacts_; ///< Sorted list of contacts
+  std::set<std::string> oldContacts_;
+
+  sva::MotionVecd v_fb_0_ = sva::MotionVecd::Zero();
+  sva::PTransformd X_0_fb_ = sva::PTransformd::Identity();
+  sva::MotionVecd a_fb_0_ = sva::MotionVecd::Zero();
+
+  leggedOdometry::LeggedOdometryManager odometryManager_;
+
+  bool accUpdatedUpstream_ = false;
+
+  using LoContactsManager = leggedOdometry::LeggedOdometryManager::ContactsManager;
+};
+
+} // namespace mc_state_observation

--- a/include/mc_state_observation/NaiveOdometry.h
+++ b/include/mc_state_observation/NaiveOdometry.h
@@ -5,15 +5,13 @@
 #include <mc_rbdyn/Contact.h>
 #include <mc_rbdyn/Robot.h>
 
-#include <mc_state_observation/observersTools/leggedOdometryTools.h>
+#include <mc_state_observation/odometry/leggedOdometry.h>
 #include <state-observation/dynamics-estimators/kinetics-observer.hpp>
 
 #include <mc_observers/Observer.h>
 
 namespace mc_state_observation
 {
-namespace so = stateObservation;
-
 struct NaiveOdometry : public mc_observers::Observer
 {
 
@@ -125,11 +123,11 @@ private:
   sva::PTransformd X_0_fb_ = sva::PTransformd::Identity();
   sva::MotionVecd a_fb_0_ = sva::MotionVecd::Zero();
 
-  leggedOdometry::LeggedOdometryManager odometryManager_;
+  odometry::LeggedOdometryManager odometryManager_;
 
   bool accUpdatedUpstream_ = false;
 
-  using LoContactsManager = leggedOdometry::LeggedOdometryManager::ContactsManager;
+  using LoContactsManager = odometry::LeggedOdometryManager::ContactsManager;
 };
 
 } // namespace mc_state_observation

--- a/include/mc_state_observation/NaiveOdometry.h
+++ b/include/mc_state_observation/NaiveOdometry.h
@@ -2,13 +2,8 @@
 
 #pragma once
 
-#include <mc_rbdyn/Contact.h>
-#include <mc_rbdyn/Robot.h>
-
 #include <mc_state_observation/odometry/LeggedOdometryManager.h>
 #include <state-observation/dynamics-estimators/kinetics-observer.hpp>
-
-#include <mc_observers/Observer.h>
 
 namespace mc_state_observation
 {

--- a/include/mc_state_observation/NaiveOdometry.h
+++ b/include/mc_state_observation/NaiveOdometry.h
@@ -103,7 +103,7 @@ public:
   inline const sva::PTransformd & posW() const { return X_0_fb_; }
 
 private:
-  std::string category_ = "NaiveOdometry_";
+  std::string category_ = "NaiveOdometry";
   /* custom list of robots to display */
   std::shared_ptr<mc_rbdyn::Robots> my_robots_;
 

--- a/include/mc_state_observation/NaiveOdometry.h
+++ b/include/mc_state_observation/NaiveOdometry.h
@@ -102,11 +102,6 @@ public:
    */
   inline const sva::PTransformd & posW() const { return X_0_fb_; }
 
-  /** Floating-base velocity estimate.
-   *
-   */
-  inline const sva::MotionVecd & velW() const { return v_fb_0_; }
-
 private:
   std::string category_ = "NaiveOdometry_";
   /* custom list of robots to display */
@@ -119,13 +114,15 @@ private:
   // std::set<std::string> contacts_; ///< Sorted list of contacts
   std::set<std::string> oldContacts_;
 
-  sva::MotionVecd v_fb_0_ = sva::MotionVecd::Zero();
+  // estimated pose of the floating base
   sva::PTransformd X_0_fb_ = sva::PTransformd::Identity();
-  sva::MotionVecd a_fb_0_ = sva::MotionVecd::Zero();
+  // estimated velocity of the floating base
+  sva::MotionVecd v_0_fb;
 
   odometry::LeggedOdometryManager odometryManager_;
 
-  bool accUpdatedUpstream_ = false;
+  // indicates if the velocity has to be updated, if yes, how it must be updated
+  odometry::LeggedOdometryManager::VelocityUpdate velUpdate_ = odometry::LeggedOdometryManager::noUpdate;
 
   using LoContactsManager = odometry::LeggedOdometryManager::ContactsManager;
 };

--- a/include/mc_state_observation/NaiveOdometry.h
+++ b/include/mc_state_observation/NaiveOdometry.h
@@ -5,7 +5,7 @@
 #include <mc_rbdyn/Contact.h>
 #include <mc_rbdyn/Robot.h>
 
-#include <mc_state_observation/odometry/leggedOdometry.h>
+#include <mc_state_observation/odometry/LeggedOdometryManager.h>
 #include <state-observation/dynamics-estimators/kinetics-observer.hpp>
 
 #include <mc_observers/Observer.h>

--- a/include/mc_state_observation/NaiveOdometry.h
+++ b/include/mc_state_observation/NaiveOdometry.h
@@ -116,9 +116,6 @@ private:
 
   odometry::LeggedOdometryManager odometryManager_;
 
-  // indicates if the velocity has to be updated, if yes, how it must be updated
-  odometry::LeggedOdometryManager::VelocityUpdate velUpdate_ = odometry::LeggedOdometryManager::noUpdate;
-
   using LoContactsManager = odometry::LeggedOdometryManager::ContactsManager;
 };
 

--- a/include/mc_state_observation/ObjectObserver.h
+++ b/include/mc_state_observation/ObjectObserver.h
@@ -17,6 +17,8 @@ struct ObjectObserver : public mc_observers::Observer
 
   ObjectObserver(const std::string & type, double dt);
 
+  ~ObjectObserver();
+
   void configure(const mc_control::MCController & ctl, const mc_rtc::Configuration &) override;
 
   void reset(const mc_control::MCController & ctl) override;
@@ -76,6 +78,7 @@ protected:
   mc_rtc::NodeHandlePtr nh_ = nullptr;
   void rosSpinner();
   std::thread thread_;
+  bool thread_run_ = true;
 
   bool isEstimatedPoseValid_ = false;
 

--- a/include/mc_state_observation/SLAMObserver.h
+++ b/include/mc_state_observation/SLAMObserver.h
@@ -19,6 +19,8 @@ struct SLAMObserver : public mc_observers::Observer
 
   SLAMObserver(const std::string & type, double dt);
 
+  ~SLAMObserver();
+
   void configure(const mc_control::MCController & ctl, const mc_rtc::Configuration &) override;
 
   void reset(const mc_control::MCController & ctl) override;
@@ -85,6 +87,7 @@ protected:
   mc_rtc::NodeHandlePtr nh_ = nullptr;
   void rosSpinner();
   std::thread thread_;
+  bool thread_run_ = true;
   tf2_ros::Buffer tfBuffer_;
   tf2_ros::TransformListener tfListener_{tfBuffer_};
   tf2_ros::TransformBroadcaster tfBroadcaster_;

--- a/include/mc_state_observation/TiltObserver.h
+++ b/include/mc_state_observation/TiltObserver.h
@@ -1,0 +1,222 @@
+#pragma once
+
+#include <mc_observers/Observer.h>
+#include <boost/circular_buffer.hpp>
+#include <mc_state_observation/observersTools/leggedOdometryTools.h>
+#include <state-observation/observer/tilt-estimator-humanoid.hpp>
+#include <state-observation/tools/rigid-body-kinematics.hpp>
+
+namespace mc_state_observation
+{
+
+struct TiltObserver : public mc_observers::Observer
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+public:
+  TiltObserver(const std::string & type, double dt);
+
+  void configure(const mc_control::MCController & ctl, const mc_rtc::Configuration &) override;
+
+  void reset(const mc_control::MCController & ctl) override;
+
+  bool run(const mc_control::MCController & ctl) override;
+
+  /// @brief updates the kinematics of the anchor frame of the robot in the world
+  /// @param ctl Controller
+  /// @param updatedRobot robot corresponding to the control robot with updated encoders
+  void updateAnchorFrame(const mc_control::MCController & ctl, const mc_rbdyn::Robot & updatedRobot);
+
+  /// @brief updates the kinematics of the anchor frame of our odometry robot in the world
+  /// @param ctl Controller
+  void updateAnchorFrameOdometry(const mc_control::MCController & ctl);
+  /// @brief updates the kinematics of the anchor frame of the robot when not performing odometry
+  /// @param ctl Controller
+  /// @param updatedRobot robot corresponding to the control robot with updated encoders
+  void updateAnchorFrameNoOdometry(const mc_control::MCController & ctl, const mc_rbdyn::Robot & updatedRobot);
+
+  /// @brief updates the pose and the velcoity of the floating base in the world frame using our estimation results
+  /// @param localWorldImuLinVel estimated local linear velocity of the IMU in the world frame
+  /// @param localWorldImuAngVelestimated measurement of the gyrometer
+  void updatePoseAndVel(const stateObservation::Vector3 & localWorldImuLinVel,
+                        const stateObservation::Vector3 & localWorldImuAngVel);
+
+  /*! \brief update the robot pose in the world only for visualization purpose
+   *
+   * @param updatedRobot Robot with the kinematics of the control robot but with updated joint values.
+   */
+  void runTiltEstimator(const mc_control::MCController & ctl, const mc_rbdyn::Robot & updatedRobot);
+
+  /// @brief Updates the real robot and/or the IMU signal using our estimation results
+  /// @param ctl Controller
+  void update(mc_control::MCController & ctl) override;
+
+  /// @brief Backup function that returns the estimated displacement of the floating base in the world wrt to the
+  /// initial one over the backup interval.
+  /// @param ctl Controller
+  /// @return const stateObservation::kine::Kinematics
+  const stateObservation::kine::Kinematics backupFb(const mc_control::MCController & ctl);
+
+  /// @brief Computes the pose transformation estimated by the Tilt Observer between the last two iterations and
+  /// applies it to the given kinematics.
+  /// @details Also fills the velocity with the velocity estimated by the Tilt Observer (expressed in the new frame)
+  /// @param kine The kinematics on which to apply the transformation
+  /// @return stateObservation::kine::Kinematics
+  stateObservation::kine::Kinematics applyLastTransformation(const stateObservation::kine::Kinematics & kine);
+
+  /// @brief checks that the odometry type used for the Kinetics Observer and the Tilt Observer match for the backup
+  /// @param koOdometryType type of odometry used by the Kinetics Observer
+  void checkCorrectBackupConf(measurements::OdometryType & koOdometryType);
+
+  /// @brief Changes the type of the odometry
+  /// @param newOdometryType The new type of odometry to use.
+  void changeOdometryType(const std::string & newOdometryType);
+
+protected:
+  /*! \brief update the robot pose in the world only for visualization purpose
+   *
+   * @param robot Robot to update
+   */
+
+  void update(mc_rbdyn::Robot & robot);
+
+  /*! \brief Add observer from logger
+   *
+   * @param category Category in which to log this observer
+   */
+  void addToLogger(const mc_control::MCController &, mc_rtc::Logger &, const std::string & category) override;
+
+  /*! \brief Remove observer from logger
+   *
+   * @param category Category in which this observer entries are logged
+   */
+  void removeFromLogger(mc_rtc::Logger &, const std::string & category) override;
+
+  /*! \brief Add observer information the GUI.
+   *
+   * @param category Category in which to add this observer
+   */
+  void addToGUI(const mc_control::MCController &,
+                mc_rtc::gui::StateBuilder &,
+                const std::vector<std::string> & /* category */) override;
+
+protected:
+  // name of the observer
+  std::string observerName_ = "TiltObserver";
+
+  // container for our robots
+  std::shared_ptr<mc_rbdyn::Robots> my_robots_;
+
+  std::string robot_; // name of the robot
+  bool updateRobot_ = true; // indicates whether we use our estimation to update the real robot or not
+  std::string imuSensor_; // IMU used for the estimation
+  bool updateSensor_ = true; // indicates whether we update the IMU signal or not
+
+  /*!
+   * parameter related to the convergence of the linear velocity
+   * of the IMU expressed in the control frame
+   */
+  double finalAlpha_ = 50;
+  ///  parameter related to the fast convergence of the tilt
+  double finalBeta_ = 5;
+  /// parameter related to the orthogonality
+  double finalGamma_ = 15;
+
+  /*!
+   * initial value of the parameter related to the convergence of the linear velocity
+   * of the IMU expressed in the control frame
+   */
+  double alpha_ = 50;
+  /// initial value of the parameter related to the fast convergence of the tilt
+  double beta_ = 5;
+  /// initial value of the parameter related to the orthogonality
+  double gamma_ = 15;
+
+  // flag indicating the variables we want in the resulting Kinematics object
+  stateObservation::kine::Kinematics::Flags::Byte flagPoseVels_ =
+      stateObservation::kine::Kinematics::Flags::position | stateObservation::kine::Kinematics::Flags::orientation
+      | stateObservation::kine::Kinematics::Flags::linVel | stateObservation::kine::Kinematics::Flags::angVel;
+
+  // function used to compute the anchor frame of the robot in the world.
+  std::string anchorFrameFunction_;
+  // instance of the Tilt Estimator for humanoid robots.
+  stateObservation::TiltEstimatorHumanoid estimator_;
+
+  /* kinematics used for computation */
+  // kinematics of the IMU in the floating base after the encoders update
+  stateObservation::kine::Kinematics updatedFbImuKine_;
+  // kinematics of the anchor frame of the control robot in the world. Version as a PTransform object.
+  sva::PTransformd X_0_C_;
+  // kinematics of the anchor frame of the control robot updated with the encoders in the world.  Version as a
+  // PTransform object.
+  sva::PTransformd X_0_C_updated_;
+  // previous value of X_0_C_updated_, used to compute the velocity by finite differences
+  sva::PTransformd X_0_C_updated_previous_;
+
+  // kinematics of the anchor frame of the control robot in the world. Version as a Kinematics object.
+  stateObservation::kine::Kinematics worldAnchorKine_;
+  // kinematics of the anchor frame of the control robot updated with the encoders in the world. Version as a Kinematics
+  // object.
+  stateObservation::kine::Kinematics updatedWorldAnchorKine_;
+
+  // kinematics of the floating base in the world after the encoders update
+  stateObservation::kine::Kinematics updatedWorldFbKine_;
+  // kinematics of the anchor frame in the IMU frame after the encoders update
+  stateObservation::kine::Kinematics updatedImuAnchorKine_;
+  // kinematics of the anchor frame in the world frame for the new iteration
+  stateObservation::kine::Kinematics newWorldAnchorKine_;
+  // kinematics of the anchor frame in the world frame for the new iteration, after the encoders update
+  stateObservation::kine::Kinematics newUpdatedWorldAnchorKine_;
+  // kinematics of the IMU in the world for the control robot
+  stateObservation::kine::Kinematics worldImuKine_;
+  // kinematics of the IMU in the world after the encoders update
+  stateObservation::kine::Kinematics updatedWorldImuKine_;
+
+  /* Estimation results */
+
+  // The observed tilt of the sensor
+  Eigen::Matrix3d estimatedRotationIMU_;
+  /// State vector estimated by the Tilt Observer
+  stateObservation::Vector xk_;
+  // estimated kinematics of the floating base in the world
+  stateObservation::kine::Kinematics correctedWorldFbKine_;
+  // estimated kinematics of the IMU in the world
+  stateObservation::kine::Kinematics correctedWorldImuKine_;
+
+  /* Floating base's kinematics */
+  Eigen::Matrix3d R_0_fb_; // estimated orientation of the floating base in the world frame
+  sva::PTransformd poseW_; ///< Estimated pose of the floating-base in world frame */
+  sva::PTransformd prevPoseW_; ///< Estimated pose of the floating-base in world frame */
+  sva::MotionVecd velW_; ///< Estimated velocity of the floating-base in world frame */
+
+  // anchor frame's variables
+  double maxAnchorFrameDiscontinuity_ =
+      0.01; ///< Threshold (norm) above wich the anchor frame is considered to have had a discontinuity
+  bool anchorFrameJumped_; /** Detects whether the anchor frame had a discontinuity */
+  int iter_; // iterations ellapsed since the beginning of the  estimation. We don't compute the anchor frame
+             // velocity while it is below "itersBeforeAnchorsVel_"
+  int itersBeforeAnchorsVel_ = 10; // iteration from which we start to compute the velocity of the anchor frame. Avoids
+                                   // initial jumps due to the finite differences.
+
+  /* Odometry parameters */
+  using OdometryType = measurements::OdometryType;
+
+  leggedOdometry::LeggedOdometryManager odometryManager_; // manager for the legged odometry
+  using LoContactsManager = leggedOdometry::LeggedOdometryManager::ContactsManager;
+  double contactDetectionThreshold_; // threshold used for the contacts detection
+
+  /* Backup function's parameters */
+
+  bool asBackup_ = false; // indicates if the estimator is used as a backup or not
+  // Buffer containing the estimated pose of the floating base in the world over the whole backup interval.
+  boost::circular_buffer<sva::PTransformd> backupFbKinematics_ = boost::circular_buffer<sva::PTransformd>(100);
+
+  /* Debug variables */
+  // "measured" local linear velocity of the IMU
+  stateObservation::Vector3 x1_;
+  // velocity of the IMU in the anchor frame
+  sva::MotionVecd imuVelC_;
+  // pose of the IMU in the anchor frame
+  sva::PTransformd X_C_IMU_;
+};
+
+} // namespace mc_state_observation

--- a/include/mc_state_observation/TiltObserver.h
+++ b/include/mc_state_observation/TiltObserver.h
@@ -2,7 +2,7 @@
 
 #include <mc_observers/Observer.h>
 #include <boost/circular_buffer.hpp>
-#include <mc_state_observation/odometry/leggedOdometry.h>
+#include <mc_state_observation/odometry/LeggedOdometryManager.h>
 #include <state-observation/observer/tilt-estimator-humanoid.hpp>
 #include <state-observation/tools/rigid-body-kinematics.hpp>
 

--- a/include/mc_state_observation/TiltObserver.h
+++ b/include/mc_state_observation/TiltObserver.h
@@ -67,9 +67,9 @@ public:
   /// @param koOdometryType type of odometry used by the Kinetics Observer
   void checkCorrectBackupConf(measurements::OdometryType & koOdometryType);
 
-  /// @brief Changes the type of the odometry
+  /// @brief Sets the type of the odometry
   /// @param newOdometryType The new type of odometry to use.
-  void changeOdometryType(const std::string & newOdometryType);
+  void setOdometryType(const std::string & newOdometryType);
 
 protected:
   /*! \brief update the robot pose in the world only for visualization purpose

--- a/include/mc_state_observation/TiltObserver.h
+++ b/include/mc_state_observation/TiltObserver.h
@@ -14,10 +14,13 @@ struct TiltObserver : public mc_observers::Observer
   friend struct MCKineticsObserver;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 public:
-  TiltObserver(const std::string & type, double dt);
-
-  /// @brief Constructor called by the Kinetics Observer when using the Tilt Observer as a backup
-  TiltObserver(const std::string & type, double dt, bool asBackup, const std::string & categoryPrefix);
+  /// @brief Constructor for the TiltObserver.
+  /// @details The parameters asBackup and observerName are given only if the Tilt Observer is used as a backup by the
+  /// Kinetics Observer
+  TiltObserver(const std::string & type,
+               double dt,
+               bool asBackup = false,
+               const std::string & observerName = "TiltObserver");
 
   void configure(const mc_control::MCController & ctl, const mc_rtc::Configuration &) override;
 
@@ -103,7 +106,7 @@ protected:
 
 protected:
   // name of the observer
-  std::string observerName_ = "TiltObserver";
+  std::string observerName_;
 
   // container for our robots
   std::shared_ptr<mc_rbdyn::Robots> my_robots_;

--- a/include/mc_state_observation/TiltObserver.h
+++ b/include/mc_state_observation/TiltObserver.h
@@ -2,7 +2,7 @@
 
 #include <mc_observers/Observer.h>
 #include <boost/circular_buffer.hpp>
-#include <mc_state_observation/observersTools/leggedOdometryTools.h>
+#include <mc_state_observation/odometry/leggedOdometry.h>
 #include <state-observation/observer/tilt-estimator-humanoid.hpp>
 #include <state-observation/tools/rigid-body-kinematics.hpp>
 
@@ -200,8 +200,8 @@ protected:
   /* Odometry parameters */
   using OdometryType = measurements::OdometryType;
 
-  leggedOdometry::LeggedOdometryManager odometryManager_; // manager for the legged odometry
-  using LoContactsManager = leggedOdometry::LeggedOdometryManager::ContactsManager;
+  odometry::LeggedOdometryManager odometryManager_; // manager for the legged odometry
+  using LoContactsManager = odometry::LeggedOdometryManager::ContactsManager;
   double contactDetectionThreshold_; // threshold used for the contacts detection
 
   /* Backup function's parameters */

--- a/include/mc_state_observation/TiltObserver.h
+++ b/include/mc_state_observation/TiltObserver.h
@@ -68,7 +68,7 @@ public:
 
   /// @brief Sets the type of the odometry
   /// @param newOdometryType The new type of odometry to use.
-  void setOdometryType(const std::string & newOdometryType);
+  void setOdometryType(measurements::OdometryType newOdometryType);
 
 protected:
   /*! \brief update the robot pose in the world only for visualization purpose

--- a/include/mc_state_observation/TiltObserver.h
+++ b/include/mc_state_observation/TiltObserver.h
@@ -120,21 +120,21 @@ protected:
    * parameter related to the convergence of the linear velocity
    * of the IMU expressed in the control frame
    */
-  double finalAlpha_ = 50;
+  double finalAlpha_ = 5;
   ///  parameter related to the fast convergence of the tilt
-  double finalBeta_ = 5;
+  double finalBeta_ = 1;
   /// parameter related to the orthogonality
-  double finalGamma_ = 15;
+  double finalGamma_ = 2;
 
   /*!
    * initial value of the parameter related to the convergence of the linear velocity
    * of the IMU expressed in the control frame
    */
-  double alpha_ = 50;
+  double alpha_ = 5;
   /// initial value of the parameter related to the fast convergence of the tilt
-  double beta_ = 5;
+  double beta_ = 1;
   /// initial value of the parameter related to the orthogonality
-  double gamma_ = 15;
+  double gamma_ = 2;
 
   // flag indicating the variables we want in the resulting Kinematics object
   stateObservation::kine::Kinematics::Flags::Byte flagPoseVels_ =

--- a/include/mc_state_observation/TiltObserver.h
+++ b/include/mc_state_observation/TiltObserver.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <mc_observers/Observer.h>
 #include <boost/circular_buffer.hpp>
+
 #include <mc_state_observation/odometry/LeggedOdometryManager.h>
 #include <state-observation/observer/tilt-estimator-humanoid.hpp>
-#include <state-observation/tools/rigid-body-kinematics.hpp>
 
 namespace mc_state_observation
 {

--- a/include/mc_state_observation/odometry/LeggedOdometryManager.h
+++ b/include/mc_state_observation/odometry/LeggedOdometryManager.h
@@ -385,17 +385,6 @@ private:
   /// @param contactName
   void removeContactLogEntries(mc_rtc::Logger & logger, const LoContactWithSensor & contact);
 
-public:
-  // Indicates if the mode of computation of the anchor frame changed. Might me needed by the estimator (ex;
-  // TiltObserver)
-  bool prevAnchorFromContacts_ = true;
-  // Indicates if the desired odometry must be a flat or a 6D odometry.
-  using OdometryType = measurements::OdometryType;
-  measurements::OdometryType odometryType_;
-
-  // indicates if the velocity has to be updated, if yes, how it must be updated
-  VelocityUpdate velocityUpdate_;
-
 protected:
   // Name of the odometry, used in logs and in the gui.
   std::string odometryName_;
@@ -413,6 +402,22 @@ protected:
   std::shared_ptr<mc_rbdyn::Robots> odometryRobot_;
   // pose of the anchor frame of the robot in the world
   stateObservation::kine::Kinematics worldAnchorPose_;
+
+  // Indicates if the previous anchor frame was obtained using contacts
+  bool prevAnchorFromContacts_ = true;
+  // Indicates if the current anchor frame was obtained using contacts
+  bool currAnchorFromContacts_ = true;
+  // Indicates if the mode of computation of the anchor frame changed. Might me needed by the estimator (ex:
+
+public:
+  // TiltObserver)
+  bool anchorFrameMethodChanged_ = false;
+  // Indicates if the desired odometry must be a flat or a 6D odometry.
+  using OdometryType = measurements::OdometryType;
+  measurements::OdometryType odometryType_;
+
+  // indicates if the velocity has to be updated, if yes, how it must be updated
+  VelocityUpdate velocityUpdate_;
 };
 
 } // namespace mc_state_observation::odometry

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,8 +27,9 @@ endmacro()
 
 macro(add_so_observer observer_name)
   add_simple_observer(${observer_name})
-  target_link_libraries(${observer_name}
-                        PUBLIC state-observation::state-observation)
+  target_link_libraries(
+    ${observer_name} PUBLIC state-observation::state-observation
+                            mc_state_observation)
 endmacro()
 
 macro(add_observer_with_filter observer_name)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,18 @@ macro(add_so_observer observer_name)
                             mc_state_observation)
 endmacro()
 
+macro(add_kineticsobserver)
+  add_observer(
+    MCKineticsObserver "MCKineticsObserver.cpp"
+    "${CMAKE_SOURCE_DIR}/include/${PROJECT_NAME}/MCKineticsObserver.h")
+  # mc_observers doesn't actually depend on mc_control, but the observer's
+  # implementation does
+  target_link_libraries(
+    MCKineticsObserver
+    PUBLIC mc_rtc::mc_control state-observation::state-observation
+           mc_state_observation TiltObserver)
+endmacro()
+
 macro(add_observer_with_filter observer_name)
   add_observer(
     ${observer_name}
@@ -42,9 +54,9 @@ macro(add_observer_with_filter observer_name)
 endmacro()
 
 add_so_observer(AttitudeObserver)
-add_so_observer(MCKineticsObserver)
 add_so_observer(NaiveOdometry)
 add_so_observer(TiltObserver)
+add_kineticsobserver()
 
 if(WITH_ROS_OBSERVERS)
   add_simple_observer(MocapObserver)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,9 @@ macro(add_observer_with_filter observer_name)
 endmacro()
 
 add_so_observer(AttitudeObserver)
+add_so_observer(MCKineticsObserver)
+add_so_observer(NaiveOdometry)
+add_so_observer(TiltObserver)
 
 if(WITH_ROS_OBSERVERS)
   add_simple_observer(MocapObserver)

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -1,0 +1,1747 @@
+/* Copyright 2017-2020 CNRS-AIST JRL, CNRS-UM LIRMM */
+
+#include <mc_control/MCController.h>
+#include <mc_observers/ObserverMacros.h>
+#include <mc_rtc/io_utils.h>
+#include <mc_rtc/logging.h>
+#include "mc_state_observation/observersTools/measurementsTools.h"
+#include <mc_state_observation/MCKineticsObserver.h>
+#include <mc_state_observation/gui_helpers.h>
+
+#include <RBDyn/CoM.h>
+#include <RBDyn/FA.h>
+#include <RBDyn/FK.h>
+#include <RBDyn/FV.h>
+
+#include <typeinfo>
+
+#include <mc_state_observation/observersTools/kinematicsTools.h>
+
+namespace so = stateObservation;
+
+namespace mc_state_observation
+{
+MCKineticsObserver::MCKineticsObserver(const std::string & type, double dt)
+: mc_observers::Observer(type, dt), observer_(4, 2)
+{
+  observer_.setSamplingTime(dt);
+}
+
+///////////////////////////////////////////////////////////////////////
+/// --------------------------Core functions---------------------------
+///////////////////////////////////////////////////////////////////////
+
+void MCKineticsObserver::configure(const mc_control::MCController & ctl, const mc_rtc::Configuration & config)
+{
+  robot_ = config("robot", ctl.robot().name());
+
+  const auto & robot = ctl.robot(robot_);
+
+  IMUs_ = config("imuSensor", ctl.robot().bodySensors());
+  config("debug", debug_);
+  config("verbose", verbose_);
+
+  std::string typeOfOdometry = static_cast<std::string>(config("odometryType"));
+
+  if(typeOfOdometry == "flatOdometry") { odometryType_ = measurements::flatOdometry; }
+  else if(typeOfOdometry == "6dOdometry") { odometryType_ = measurements::odometry6d; }
+  else if(typeOfOdometry == "None") { odometryType_ = measurements::None; }
+  else
+  {
+    mc_rtc::log::error_and_throw<std::runtime_error>(
+        "Odometry type not allowed. Please pick among : [None, flatOdometry, 6dOdometry]");
+  }
+
+  config("withDebugLogs", withDebugLogs_);
+
+  config("withFilteredForcesContactDetection", withFilteredForcesContactDetection_);
+
+  /* configuration of the contacts manager */
+
+  contactsManager_.init(observerName_, true);
+
+  double contactDetectionPropThreshold = config("contactDetectionPropThreshold", 0.11);
+  contactDetectionThreshold_ = robot.mass() * so::cst::gravityConstant * contactDetectionPropThreshold;
+
+  std::string contactsDetection = static_cast<std::string>(config("contactsDetection"));
+
+  KoContactsManager::ContactsDetection contactsDetectionMethod = KoContactsManager::ContactsDetection::undefined;
+  if(contactsDetection == "fromThreshold")
+  {
+    contactsDetectionMethod = KoContactsManager::ContactsDetection::fromThreshold;
+  }
+  else if(contactsDetection == "fromSurfaces")
+  {
+    contactsDetectionMethod = KoContactsManager::ContactsDetection::fromSurfaces;
+  }
+  else if(contactsDetection == "fromSolver")
+  {
+    contactsDetectionMethod = KoContactsManager::ContactsDetection::fromSolver;
+  }
+
+  std::vector<std::string> contactsSensorsDisabledInit =
+      config("contactsSensorDisabledInit", std::vector<std::string>());
+  config("forceSensorsAsInput", forceSensorsAsInput_);
+
+  if(contactsDetectionMethod == KoContactsManager::ContactsDetection::fromSurfaces)
+  {
+    std::vector<std::string> surfacesForContactDetection =
+        config("surfacesForContactDetection", std::vector<std::string>());
+
+    contactsManager_.initDetection(ctl, robot_, contactsDetectionMethod, surfacesForContactDetection,
+                                   contactsSensorsDisabledInit, contactDetectionThreshold_);
+  }
+  else
+  {
+    contactsManager_.initDetection(ctl, robot_, contactsDetectionMethod, contactsSensorsDisabledInit,
+                                   contactDetectionThreshold_, forceSensorsAsInput_);
+  }
+
+  if(withFilteredForcesContactDetection_)
+  {
+    mc_rtc::log::error_and_throw<std::runtime_error>("The forces filtering has an error, please don't use it now");
+  }
+
+  /* Configuration of the Kinetics Observer's parameters */
+
+  config("withUnmodeledWrench", withUnmodeledWrench_);
+  config("withGyroBias", withGyroBias_);
+
+  observer_.setWithUnmodeledWrench(withUnmodeledWrench_);
+  observer_.setWithGyroBias(withGyroBias_);
+  observer_.useFiniteDifferencesJacobians(config("withFiniteDifferences"));
+  so::Vector dx(observer_.getStateSize());
+  dx.setConstant(static_cast<double>(config("finiteDifferenceStep")));
+  observer_.setFiniteDifferenceStep(dx);
+  observer_.setWithAccelerationEstimation(config("withAccelerationEstimation"));
+
+  linStiffness_ = (config("linStiffness").operator so::Vector3()).matrix().asDiagonal();
+  angStiffness_ = (config("angStiffness").operator so::Vector3()).matrix().asDiagonal();
+  linDamping_ = (config("linDamping").operator so::Vector3()).matrix().asDiagonal();
+  angDamping_ = (config("angDamping").operator so::Vector3()).matrix().asDiagonal();
+
+  zeroPose_.translation().setZero();
+  zeroPose_.rotation().setIdentity();
+  zeroMotion_.linear().setZero();
+  zeroMotion_.angular().setZero();
+
+  // Initial State
+  statePositionInitCovariance_ = (config("statePositionInitVariance").operator so::Vector3()).matrix().asDiagonal();
+  stateOriInitCovariance_ = (config("stateOriInitVariance").operator so::Vector3()).matrix().asDiagonal();
+  stateLinVelInitCovariance_ = (config("stateLinVelInitVariance").operator so::Vector3()).matrix().asDiagonal();
+  stateAngVelInitCovariance_ = (config("stateAngVelInitVariance").operator so::Vector3()).matrix().asDiagonal();
+  gyroBiasInitCovariance_.setZero();
+  unmodeledWrenchInitCovariance_.setZero();
+  contactInitCovarianceFirstContacts_.setZero();
+  contactInitCovarianceFirstContacts_.block<3, 3>(0, 0) =
+      (config("contactPositionInitVarianceFirstContacts").operator so::Vector3()).matrix().asDiagonal();
+  contactInitCovarianceFirstContacts_.block<3, 3>(3, 3) =
+      (config("contactOriInitVarianceFirstContacts").operator so::Vector3()).matrix().asDiagonal();
+  contactInitCovarianceFirstContacts_.block<3, 3>(6, 6) =
+      (config("contactForceInitVarianceFirstContacts").operator so::Vector3()).matrix().asDiagonal();
+  contactInitCovarianceFirstContacts_.block<3, 3>(9, 9) =
+      (config("contactTorqueInitVarianceFirstContacts").operator so::Vector3()).matrix().asDiagonal();
+
+  contactInitCovarianceNewContacts_.setZero();
+  contactInitCovarianceNewContacts_.block<3, 3>(0, 0) =
+      (config("contactPositionInitVarianceNewContacts").operator so::Vector3()).matrix().asDiagonal();
+  contactInitCovarianceNewContacts_.block<3, 3>(3, 3) =
+      (config("contactOriInitVarianceNewContacts").operator so::Vector3()).matrix().asDiagonal();
+  contactInitCovarianceNewContacts_.block<3, 3>(6, 6) =
+      (config("contactForceInitVarianceNewContacts").operator so::Vector3()).matrix().asDiagonal();
+  contactInitCovarianceNewContacts_.block<3, 3>(9, 9) =
+      (config("contactTorqueInitVarianceNewContacts").operator so::Vector3()).matrix().asDiagonal();
+
+  // Process //
+  statePositionProcessCovariance_ =
+      (config("statePositionProcessVariance").operator so::Vector3()).matrix().asDiagonal();
+  stateOriProcessCovariance_ = (config("stateOriProcessVariance").operator so::Vector3()).matrix().asDiagonal();
+  stateLinVelProcessCovariance_ = (config("stateLinVelProcessVariance").operator so::Vector3()).matrix().asDiagonal();
+  stateAngVelProcessCovariance_ = (config("stateAngVelProcessVariance").operator so::Vector3()).matrix().asDiagonal();
+  gyroBiasProcessCovariance_.setZero();
+  unmodeledWrenchProcessCovariance_.setZero();
+
+  contactProcessCovariance_.setZero();
+  contactProcessCovariance_.block<3, 3>(0, 0) =
+      (config("contactPositionProcessVariance").operator so::Vector3()).matrix().asDiagonal();
+  contactProcessCovariance_.block<3, 3>(3, 3) =
+      (config("contactOrientationProcessVariance").operator so::Vector3()).matrix().asDiagonal();
+  contactProcessCovariance_.block<3, 3>(6, 6) =
+      (config("contactForceProcessVariance").operator so::Vector3()).matrix().asDiagonal();
+  contactProcessCovariance_.block<3, 3>(9, 9) =
+      (config("contactTorqueProcessVariance").operator so::Vector3()).matrix().asDiagonal();
+
+  // Unmodeled Wrench //
+  if(withUnmodeledWrench_)
+  {
+    // initial
+    unmodeledWrenchInitCovariance_.block<3, 3>(0, 0) =
+        (config("unmodeledForceInitVariance").operator so::Vector3()).matrix().asDiagonal();
+    unmodeledWrenchInitCovariance_.block<3, 3>(3, 3) =
+        (config("unmodeledTorqueInitVariance").operator so::Vector3()).matrix().asDiagonal();
+
+    // process
+    unmodeledWrenchProcessCovariance_.block<3, 3>(0, 0) =
+        (config("unmodeledForceProcessVariance").operator so::Vector3()).matrix().asDiagonal();
+    unmodeledWrenchProcessCovariance_.block<3, 3>(3, 3) =
+        (config("unmodeledTorqueProcessVariance").operator so::Vector3()).matrix().asDiagonal();
+  }
+  // Gyrometer Bias
+  if(withGyroBias_)
+  {
+    gyroBiasInitCovariance_ = (config("gyroBiasInitVariance").operator so::Vector3()).matrix().asDiagonal();
+    gyroBiasProcessCovariance_ = (config("gyroBiasProcessVariance").operator so::Vector3()).matrix().asDiagonal();
+  }
+
+  // Sensor //
+  positionSensorCovariance_ = (config("positionSensorVariance").operator so::Vector3()).matrix().asDiagonal();
+  orientationSensorCoVariance_ = (config("orientationSensorVariance").operator so::Vector3()).matrix().asDiagonal();
+  acceleroSensorCovariance_ = (config("acceleroSensorVariance").operator so::Vector3()).matrix().asDiagonal();
+  gyroSensorCovariance_ = (config("gyroSensorVariance").operator so::Vector3()).matrix().asDiagonal();
+  absoluteOriSensorCovariance_ = (config("absOriSensorVariance").operator so::Vector3()).matrix().asDiagonal();
+  contactSensorCovariance_.setZero();
+  contactSensorCovariance_.block<3, 3>(0, 0) =
+      (config("forceSensorVariance").operator so::Vector3()).matrix().asDiagonal();
+  contactSensorCovariance_.block<3, 3>(3, 3) =
+      (config("torqueSensorVariance").operator so::Vector3()).matrix().asDiagonal();
+
+  setObserverCovariances();
+
+  /* Configuration of the backup based on the Tilt Observer */
+
+  if(!ctl.datastore().has("runBackup"))
+  {
+    // if the datastore must contain the backup function provided by the Tilt Observer
+    mc_rtc::log::error_and_throw<std::runtime_error>(
+        "The Tilt Observer must be used before the Kinetics Observer when used as a backup");
+  }
+
+  // interval (in s) on which the backup will recover
+  int backupInterval = config("backupInterval", 1);
+  auto & datastore = (const_cast<mc_control::MCController &>(ctl)).datastore();
+  datastore.make<int>("KoBackupInterval", backupInterval);
+
+  backupIterInterval_ = int(backupInterval / ctl.timeStep);
+
+  koBackupFbKinematics_.resize(backupIterInterval_);
+
+  datastore.make<int>("koBackupIterInterval", backupIterInterval_);
+  datastore.make<boost::circular_buffer<stateObservation::kine::Kinematics> *>("koBackupFbKinematics",
+                                                                               &koBackupFbKinematics_);
+
+  invincibilityFrame_ = int(1.5 / ctl.timeStep);
+
+  ctl.gui()->addElement({observerName_},
+                        mc_rtc::gui::Button("SimulateNanBehaviour", [this]() { observer_.nanDetected_ = true; }));
+}
+
+void MCKineticsObserver::setObserverCovariances()
+{
+  // initialization of the observers covariances
+  observer_.setKinematicsInitCovarianceDefault(statePositionInitCovariance_, stateOriInitCovariance_,
+                                               stateLinVelInitCovariance_, stateAngVelInitCovariance_);
+  observer_.setGyroBiasInitCovarianceDefault(gyroBiasInitCovariance_);
+  observer_.setUnmodeledWrenchInitCovMatDefault(unmodeledWrenchInitCovariance_);
+  observer_.setContactInitCovMatDefault(contactInitCovarianceFirstContacts_);
+  observer_.resetStateCovarianceMat();
+
+  observer_.setKinematicsProcessCovarianceDefault(statePositionProcessCovariance_, stateOriProcessCovariance_,
+                                                  stateLinVelProcessCovariance_, stateAngVelProcessCovariance_);
+  observer_.setGyroBiasProcessCovarianceDefault(gyroBiasProcessCovariance_);
+  observer_.setUnmodeledWrenchProcessCovarianceDefault(unmodeledWrenchProcessCovariance_);
+  observer_.setContactProcessCovarianceDefault(contactProcessCovariance_);
+
+  observer_.resetProcessCovarianceMat();
+
+  observer_.setIMUDefaultCovarianceMatrix(acceleroSensorCovariance_, gyroSensorCovariance_);
+  observer_.setContactWrenchSensorDefaultCovarianceMatrix(contactSensorCovariance_);
+  so::Matrix6 absPoseSensorDefCovariance = so::Matrix6::Zero();
+  absPoseSensorDefCovariance.block(0, 0, observer_.sizePos, observer_.sizePos) = positionSensorCovariance_;
+  absPoseSensorDefCovariance.block(observer_.sizePos, observer_.sizePos, observer_.sizeOriTangent,
+                                   observer_.sizeOriTangent) = orientationSensorCoVariance_;
+  observer_.setAbsolutePoseSensorDefaultCovarianceMatrix(absPoseSensorDefCovariance);
+  observer_.setAbsoluteOriSensorDefaultCovarianceMatrix(absoluteOriSensorCovariance_);
+}
+
+void MCKineticsObserver::reset(const mc_control::MCController & ctl)
+{
+  const auto & robot = ctl.robot(robot_);
+  const auto & realRobot = ctl.realRobot(robot_);
+  const auto & realRobotModule = realRobot.module();
+
+  rbd::MultiBodyGraph mergeMbg(realRobotModule.mbg);
+  std::map<std::string, std::vector<double>> jointPosByName;
+  for(int i = 0; i < realRobotModule.mb.nrJoints(); ++i)
+  {
+    auto jointName = realRobotModule.mb.joint(i).name();
+    auto jointIndex = static_cast<unsigned long>(realRobotModule.mb.jointIndexByName(jointName));
+    jointPosByName[jointName] = realRobotModule.mbc.q[jointIndex];
+  }
+
+  std::vector<std::string> rootJoints = {};
+  int nbJoints = static_cast<int>(realRobot.mb().joints().size());
+  for(int i = 0; i < nbJoints; ++i)
+  {
+    if(realRobot.mb().predecessor(i) == 0) { rootJoints.push_back(realRobot.mb().joint(i).name()); }
+  }
+  for(const auto & joint : rootJoints)
+  {
+    if(!realRobot.hasJoint(joint))
+    {
+      mc_rtc::log::error_and_throw<std::runtime_error>("Robot does not have a joint named {}", joint);
+    }
+    mergeMbg.mergeSubBodies(realRobotModule.mb.body(0).name(), joint, jointPosByName);
+  }
+
+  inertiaWaist_ = mergeMbg.nodeByName(realRobotModule.mb.body(0).name())->body.inertia();
+  mass(ctl.realRobot(robot_).mass());
+
+  for(const auto & imu : IMUs_) { mapIMUs_.insertIMU(imu.name()); }
+
+  if(debug_) { mc_rtc::log::info("inertiaWaist = {}", inertiaWaist_); }
+
+  /* Initialization of variables */
+  X_0_fb_ = sva::PTransformd::Identity();
+  v_fb_0_ = sva::MotionVecd::Zero();
+  a_fb_0_ = sva::MotionVecd::Zero();
+  lastBackupIter_ = 0;
+  invincibilityIter_ = 0;
+
+  my_robots_ = mc_rbdyn::Robots::make();
+  my_robots_->robotCopy(robot, robot.name());
+  my_robots_->robotCopy(realRobot, "inputRobot");
+  ctl.gui()->addElement(
+      {"Robots"},
+      mc_rtc::gui::Robot(observerName_, [this]() -> const mc_rbdyn::Robot & { return my_robots_->robot(); }));
+  ctl.gui()->addElement({"Robots"},
+                        mc_rtc::gui::Robot("Real", [&ctl]() -> const mc_rbdyn::Robot & { return ctl.realRobot(); }));
+
+  X_0_fb_ = robot.posW().translation();
+
+  initObserverStateVector(realRobot);
+}
+
+void MCKineticsObserver::addSensorsAsInputs(const mc_rbdyn::Robot & inputRobot,
+                                            const mc_rbdyn::Robot & measRobot,
+                                            so::Vector3 & inputAddtionalForce,
+                                            so::Vector3 & inputAddtionalTorque)
+{
+  for(const std::string & fsName : forceSensorsAsInput_)
+  {
+    const mc_rbdyn::ForceSensor & forceSensor = measRobot.forceSensor(fsName);
+    sva::ForceVecd measuredWrench = forceSensor.worldWrenchWithoutGravity(inputRobot);
+
+    inputAddtionalForce += measuredWrench.force();
+    inputAddtionalTorque += measuredWrench.moment();
+  }
+}
+
+bool MCKineticsObserver::run(const mc_control::MCController & ctl)
+{
+  const auto & robot = ctl.robot(robot_);
+  const auto & realRobot = ctl.realRobot(robot_);
+  auto & inputRobot = my_robots_->robot("inputRobot");
+  auto & logger = (const_cast<mc_control::MCController &>(ctl)).logger();
+
+  inputRobot.mbc() = realRobot.mbc();
+  inputRobot.mb() = realRobot.mb();
+
+  // The input robot copies the real robot to update the encoder values.
+  // Then its floating base is brung back to the origin of the world frame and given zero velocities and accelerations
+  // in order to ease the computations.
+  inputRobot.posW(zeroPose_);
+  inputRobot.velW(zeroMotion_);
+  inputRobot.accW(zeroMotion_);
+
+  /** Center of mass (assumes FK, FV and FA are already done)
+      Must be initialized now as used for the conversion from user to centroid frame !!! **/
+  worldCoMKine_.position = inputRobot.com();
+  worldCoMKine_.linVel = inputRobot.comVelocity();
+  worldCoMKine_.linAcc = inputRobot.comAcceleration();
+
+  observer_.setCenterOfMass(worldCoMKine_.position(), worldCoMKine_.linVel(), worldCoMKine_.linAcc());
+
+  /** Contacts
+   * Note that when we use force sensors directly for the contact detection, the pose of the contact is the one of the
+   * force sensor and not the contact surface!
+   */
+  // retrieves the list of contacts and set simStarted to true once a contact is detected
+  updateContacts(ctl, findNewContacts(ctl), logger);
+
+  // force measurements from sensor that are not associated to a currently set contact are given to the Kinetics
+  // Observer as inputs.
+  inputAdditionalWrench(inputRobot, robot);
+
+  /** Accelerometers **/
+  updateIMUs(robot, inputRobot);
+
+  /*
+  so::kine::Orientation oriMeasurement;
+  //oriMeasurement = so::Matrix3(realRobot.posW().rotation().transpose());
+  observer_.setAbsoluteOriSensor(oriMeasurement);
+  */
+
+  /** Inertias **/
+  /** TODO : Merge inertias into CoM inertia and/or get it from fd() **/
+
+  observer_.setCoMAngularMomentum(
+      rbd::computeCentroidalMomentum(inputRobot.mb(), inputRobot.mbc(), inputRobot.com()).moment());
+
+  observer_.setCoMInertiaMatrix(so::Matrix3(
+      inertiaWaist_.inertia() + observer_.getMass() * so::kine::skewSymmetric2(observer_.getCenterOfMass()())));
+  /* Step once, and return result */
+
+  res_ = observer_.update();
+
+  // Kinematics of the floating base in the real world frame (our estimation goal)
+  so::kine::Kinematics mcko_K_0_fb;
+
+  if(observer_.nanDetected_) { estimationState_ = errorDetected; }
+  else if(invincibilityIter_ > 0 && invincibilityIter_ < invincibilityFrame_) { estimationState_ = invincibilityFrame; }
+  else { estimationState_ = noIssue; }
+
+  // if no anomaly is detected and if we aren't in the "invicibility frame", we update the floating base with the
+  // results of the Kinetics Observer
+  switch(estimationState_)
+  {
+    case noIssue:
+    {
+      /* Core */
+      so::kine::Kinematics fbFb; // "Zero" Kinematics
+      fbFb.setZero<so::Matrix3>(so::kine::Kinematics::Flags::all);
+
+      // Given, the Kinematics of the floating base inside its own frame (zero kinematics) which is our user
+      // frame, the Kinetics Observer will return the kinematics of the floating base in the real world frame.
+      mcko_K_0_fb = observer_.getGlobalKinematicsOf(fbFb);
+
+      koBackupFbKinematics_.push_back(mcko_K_0_fb);
+
+      X_0_fb_.rotation() = mcko_K_0_fb.orientation.toMatrix3().transpose();
+      X_0_fb_.translation() = mcko_K_0_fb.position();
+
+      /* Bring velocity of the IMU to the origin of the joint : we want the
+       * velocity of joint 0, so stop one before the first joint */
+
+      v_fb_0_.angular() = mcko_K_0_fb.angVel();
+      v_fb_0_.linear() = mcko_K_0_fb.linVel();
+
+      a_fb_0_.angular() = mcko_K_0_fb.angAcc();
+      a_fb_0_.linear() = mcko_K_0_fb.linAcc();
+      break;
+    }
+    case invincibilityFrame:
+    {
+      auto & datastore = (const_cast<mc_control::MCController &>(ctl)).datastore();
+      // we apply the last transformation estimated by the Tilt Observer to our previous pose to keep updating the
+      // floating base with the Tilt Observer.
+      mcko_K_0_fb = datastore.call<so::kine::Kinematics>("applyLastTransformation", koBackupFbKinematics_.back());
+      koBackupFbKinematics_.push_back(mcko_K_0_fb);
+
+      X_0_fb_.rotation() = mcko_K_0_fb.orientation.toMatrix3().transpose();
+      X_0_fb_.translation() = mcko_K_0_fb.position();
+
+      // the tilt observer doesn't estimate the acceleration so we get it by finite differences
+      a_fb_0_.angular() = (mcko_K_0_fb.angVel() - v_fb_0_.angular()) / ctl.timeStep;
+      a_fb_0_.linear() = (mcko_K_0_fb.linVel() - v_fb_0_.linear()) / ctl.timeStep;
+
+      v_fb_0_.angular() = mcko_K_0_fb.angVel();
+      v_fb_0_.linear() = mcko_K_0_fb.linVel();
+
+      invincibilityIter_++;
+      // While converging again after being reset, the estimation made by the Kinetics Observer is very inaccurate and
+      // cannot be used. So we let it converge during the invincibility frame while using the estimation of the Tilt to
+      // update the real robot. Then we start over using the Kinetics Observer starting from the final kinematics
+      // obtained from the Tilt Observer.
+      if(invincibilityIter_ == invincibilityFrame_)
+      {
+        update(inputRobot);
+        inputRobot.forwardKinematics();
+        so::kine::Kinematics fbFb; // "Zero" Kinematics
+        fbFb.setZero<so::Matrix3>(so::kine::Kinematics::Flags::all);
+        so::kine::Kinematics newWorldCentroidKine;
+        newWorldCentroidKine.position = inputRobot.com();
+        // the orientation of the centroid frame is the one of the floating base
+        newWorldCentroidKine.orientation = mcko_K_0_fb.orientation;
+
+        newWorldCentroidKine.linVel = inputRobot.comVelocity();
+        newWorldCentroidKine.angVel = mcko_K_0_fb.angVel();
+
+        observer_.setWorldCentroidStateKinematics(newWorldCentroidKine, false);
+
+        for(const int & contactIndex : contactsManager_.contactsFound())
+        {
+          KoContactWithSensor contact = contactsManager_.contactWithSensor(contactIndex);
+
+          // Update of the force measurements (the contribution of the gravity changed)
+          const mc_rbdyn::ForceSensor & forceSensor = robot.forceSensor(contact.forceSensorName());
+
+          // the tilt of the robot changed so the contribution of the gravity to the measurements changed too
+          if(KoContactsManager().getContactsDetection() == KoContactsManager::ContactsDetection::fromThreshold)
+          {
+            updateContactForceMeasurement(contact, forceSensor.wrenchWithoutGravity(inputRobot));
+          }
+          else // the kinematics of the contact are the ones of the associated surface
+          {
+            updateContactForceMeasurement(contact, contact.surfaceSensorKine_,
+                                          forceSensor.wrenchWithoutGravity(inputRobot));
+          }
+
+          so::kine::Kinematics newWorldContactKineRef;
+
+          getOdometryWorldContactRest(ctl, contact, newWorldContactKineRef);
+
+          observer_.setStateContact(contactIndex, newWorldContactKineRef, contact.contactWrenchVector_, false);
+        }
+      }
+
+      break;
+    }
+    case errorDetected:
+    {
+      // an error was just detected, we reset the state vector and covariances and start the invicibility frame, during
+      // which we let the Kinetics Observer converge before using it again.
+      auto & logger = (const_cast<mc_control::MCController &>(ctl)).logger();
+      if(logger.t() / ctl.timeStep < backupIterInterval_)
+      {
+        mc_rtc::log::warning("The backup function was called before the required time was ellapsed. The backup will be "
+                             "performed using the last {} seconds",
+                             logger.t());
+      }
+
+      if(logger.t() / ctl.timeStep - lastBackupIter_ < backupIterInterval_)
+      {
+        mc_rtc::log::warning("The backup function was called again too quickly. The backup will be "
+                             "performed using the last {} seconds",
+                             logger.t() - lastBackupIter_ * ctl.timeStep);
+      }
+
+      auto & datastore = (const_cast<mc_control::MCController &>(ctl)).datastore();
+      // We add an empty Kinematics object to the floating base pose buffer. This is because the buffer of the tilt
+      // observer already contains the last estimation of the floating base so we prevent a disalignment of the two
+      // buffers. This empty Kinematics is filled and returned by the "runBackup" function.
+      koBackupFbKinematics_.push_back(so::kine::Kinematics::zeroKinematics(so::kine::Kinematics::Flags::pose));
+      mcko_K_0_fb = datastore.call<const so::kine::Kinematics>("runBackup");
+
+      X_0_fb_.rotation() = mcko_K_0_fb.orientation.toMatrix3().transpose();
+      X_0_fb_.translation() = mcko_K_0_fb.position();
+
+      // the tilt observer doesn't estimate the acceleration so we get it by finite differences
+      a_fb_0_.angular() = (mcko_K_0_fb.angVel() - v_fb_0_.angular()) / ctl.timeStep;
+      a_fb_0_.linear() = (mcko_K_0_fb.linVel() - v_fb_0_.linear()) / ctl.timeStep;
+
+      v_fb_0_.angular() = mcko_K_0_fb.angVel();
+      v_fb_0_.linear() = mcko_K_0_fb.linVel();
+
+      // we update update robot as it will be updated at the beginning of the next iteration anyway
+      update(inputRobot);
+      inputRobot.forwardKinematics();
+      so::kine::Kinematics newWorldCentroidKine;
+      newWorldCentroidKine.position = inputRobot.com();
+      newWorldCentroidKine.linVel = inputRobot.comVelocity();
+      // the orientation of the centroid frame is the one of the floating base
+      newWorldCentroidKine.orientation = mcko_K_0_fb.orientation;
+      newWorldCentroidKine.angVel = mcko_K_0_fb.angVel();
+
+      observer_.setWorldCentroidStateKinematics(newWorldCentroidKine, true);
+      observer_.setStateUnmodeledWrench(so::Vector6::Zero(), true);
+
+      for(int i = 0; i < mapIMUs_.getList().size(); i++) { observer_.setGyroBias(so::Vector3::Zero(), i, true); }
+
+      for(const int & contactIndex : contactsManager_.contactsFound())
+      {
+        KoContactWithSensor contact = contactsManager_.contactWithSensor(contactIndex);
+
+        // Update of the force measurements (the offset due to the gravity changed)
+        const mc_rbdyn::ForceSensor & forceSensor = inputRobot.forceSensor(contact.forceSensorName());
+
+        so::kine::Kinematics bodySensorKine =
+            kinematicsTools::poseFromSva(forceSensor.X_p_f(), so::kine::Kinematics::Flags::vel);
+
+        so::kine::Kinematics bodySurfaceKine = kinematicsTools::poseFromSva(
+            inputRobot.surface(contact.surfaceName()).X_b_s(), so::kine::Kinematics::Flags::vel);
+
+        so::kine::Kinematics surfaceSensorKine = bodySurfaceKine.getInverse() * bodySensorKine;
+
+        updateContactForceMeasurement(contact, surfaceSensorKine, forceSensor.wrenchWithoutGravity(inputRobot));
+
+        so::kine::Kinematics newWorldContactKineRef;
+
+        getOdometryWorldContactRest(ctl, contact, newWorldContactKineRef);
+
+        observer_.setStateContact(contactIndex, newWorldContactKineRef, contact.contactWrenchVector_, true);
+      }
+
+      // this variable indicates that we entered the invincibility frame
+      invincibilityIter_ = 1;
+      lastBackupIter_ = int(logger.t() / ctl.timeStep);
+
+      observer_.nanDetected_ = false;
+
+      break;
+    }
+  }
+
+  if(withDebugLogs_)
+  {
+    /* Update of the logged variables */
+    correctedMeasurements_ = observer_.getEKF().getSimulatedMeasurement(observer_.getEKF().getCurrentTime());
+    globalCentroidKinematics_ = observer_.getGlobalCentroidKinematics();
+  }
+
+  /* Update of the visual representation (only a visual feature) of the observed robot */
+  my_robots_->robot().mbc().q = ctl.realRobot().mbc().q;
+
+  /* Update of the observed robot */
+  update(my_robots_->robot());
+
+  return true;
+} // namespace mc_state_observation
+
+///////////////////////////////////////////////////////////////////////
+/// -------------------------Called functions--------------------------
+///////////////////////////////////////////////////////////////////////
+
+void MCKineticsObserver::initObserverStateVector(const mc_rbdyn::Robot & robot)
+{
+  so::kine::Orientation initOrientation;
+  initOrientation.setZeroRotation<so::Quaternion>();
+  Eigen::VectorXd initStateVector;
+  initStateVector = Eigen::VectorXd::Zero(observer_.getStateSize());
+
+  initStateVector.segment(observer_.posIndex(), observer_.sizePos) = robot.com();
+  initStateVector.segment(observer_.oriIndex(), observer_.sizeOri) = initOrientation.toVector4();
+  initStateVector.segment(observer_.linVelIndex(), observer_.sizeLinVel) = robot.comVelocity();
+
+  observer_.setInitWorldCentroidStateVector(initStateVector);
+}
+
+void MCKineticsObserver::update(mc_control::MCController & ctl) // this function is called by the pipeline if the
+                                                                // update is set to true in the configuration file
+{
+  auto & datastore = (const_cast<mc_control::MCController &>(ctl)).datastore();
+  // this function checks that the backup estimator uses the same odometry type than the Kinetics Observer
+  datastore.call<>("checkCorrectBackupConf", odometryType_);
+
+  auto & realRobot = ctl.realRobot(robot_);
+  update(realRobot);
+  realRobot.forwardKinematics();
+  realRobot.forwardVelocity();
+}
+
+// used only to update the visual representation of the estimated robot
+void MCKineticsObserver::update(mc_rbdyn::Robot & robot)
+{
+  robot.posW(X_0_fb_);
+  robot.velW(v_fb_0_.vector());
+}
+
+void MCKineticsObserver::inputAdditionalWrench(const mc_rbdyn::Robot & inputRobot, const mc_rbdyn::Robot & measRobot)
+{
+  additionalUserResultingForce_.setZero();
+  additionalUserResultingMoment_.setZero();
+
+  for(auto & contactWithSensor : contactsManager_.contactsWithSensors())
+  {
+    KoContactWithSensor & contact = contactWithSensor.second;
+    const std::string & fsName = contact.forceSensorName();
+
+    if(!contact.isSet_
+       && contact.sensorEnabled_) // if the contact is not set but we use the force sensor measurements,
+                                  // then we give the measured force as an input to the Kinetics Observer
+    {
+      sva::ForceVecd measuredWrench = measRobot.forceSensor(fsName).worldWrenchWithoutGravity(inputRobot);
+      additionalUserResultingForce_ += measuredWrench.force();
+      additionalUserResultingMoment_ += measuredWrench.moment();
+    }
+  }
+
+  addSensorsAsInputs(inputRobot, measRobot, additionalUserResultingForce_, additionalUserResultingMoment_);
+
+  // We pass this computed wrench as an input to the Kinetics Observer
+  observer_.setAdditionalWrench(additionalUserResultingForce_, additionalUserResultingMoment_);
+
+  if(withDebugLogs_)
+  {
+    for(auto & contactWithSensor :
+        contactsManager_.contactsWithSensors()) // if a force sensor is not associated to a contact, its
+                                                // measurement is given as an input external wrench
+    {
+      KoContactWithSensor & contact = contactWithSensor.second;
+      const std::string & fsName = contact.forceSensorName();
+      so::Vector3 forceCentroid = so::Vector3::Zero();
+      so::Vector3 torqueCentroid = so::Vector3::Zero();
+      observer_.convertWrenchFromUserToCentroid(
+          measRobot.forceSensor(fsName).worldWrenchWithoutGravity(inputRobot).force(),
+          measRobot.forceSensor(fsName).worldWrenchWithoutGravity(inputRobot).moment(), forceCentroid, torqueCentroid);
+
+      contact.wrenchInCentroid_.segment<3>(0) = forceCentroid;
+      contact.wrenchInCentroid_.segment<3>(3) = torqueCentroid;
+    }
+  }
+}
+
+void MCKineticsObserver::updateIMUs(const mc_rbdyn::Robot & measRobot, const mc_rbdyn::Robot & inputRobot)
+{
+  for(const auto & imu : IMUs_)
+  {
+    /** Position of accelerometer **/
+
+    const sva::PTransformd & bodyImuPose = inputRobot.bodySensor(imu.name()).X_b_s();
+    so::kine::Kinematics bodyImuKine =
+        kinematicsTools::poseFromSva(bodyImuPose, so::kine::Kinematics::Flags::vel | so::kine::Kinematics::Flags::acc);
+
+    so::kine::Kinematics worldBodyKine = kinematicsTools::kinematicsFromSva(
+        inputRobot.mbc().bodyPosW[inputRobot.bodyIndexByName(imu.parentBody())],
+        inputRobot.mbc().bodyVelW[inputRobot.bodyIndexByName(imu.parentBody())],
+        inputRobot.mbc().bodyAccB[inputRobot.bodyIndexByName(imu.parentBody())], true, false);
+
+    so::kine::Kinematics worldImuKine = worldBodyKine * bodyImuKine;
+    const so::kine::Kinematics fbImuKine = worldImuKine;
+
+    observer_.setIMU(measRobot.bodySensor().linearAcceleration(), measRobot.bodySensor().angularVelocity(),
+                     acceleroSensorCovariance_, gyroSensorCovariance_, fbImuKine, mapIMUs_.getNumFromName(imu.name()));
+  }
+}
+
+const measurements::ContactsManager<KoContactWithSensor, measurements::ContactWithoutSensor>::ContactsSet &
+    MCKineticsObserver::findNewContacts(const mc_control::MCController & ctl)
+{
+  contactsManager_.findContacts(ctl, robot_);
+
+  return contactsManager_.contactsFound(); // list of currently set contacts
+}
+
+const so::kine::Kinematics MCKineticsObserver::getContactWorldKinematicsAndWrench(KoContactWithSensor & contact,
+                                                                                  const mc_rbdyn::Robot & currentRobot,
+                                                                                  const mc_rbdyn::ForceSensor & fs,
+                                                                                  const sva::ForceVecd & measuredWrench)
+{
+  /*
+  Can be used with inputRobot, a virtual robot corresponding to the real robot whose floating base's frame is
+  superimposed with the world frame. Getting kinematics associated to the inputRobot inside the world frame is the same
+  as getting the same kinematics of the real robot inside the frame of its floating base, which is needed for the inputs
+  of the Kinetics Observer. This allows to use the basic mc_rtc functions directly giving kinematics in the world frame
+  and not do the conversion: initial frame -> world + world -> floating base as the latter is zero.
+  */
+
+  so::kine::Kinematics worldContactKine;
+
+  const sva::PTransformd & bodyContactSensorPose = fs.X_p_f();
+  so::kine::Kinematics bodyContactSensorKine =
+      kinematicsTools::poseFromSva(bodyContactSensorPose, so::kine::Kinematics::Flags::vel);
+
+  // kinematics of the sensor's parent body in the world
+  so::kine::Kinematics worldBodyKine = kinematicsTools::poseAndVelFromSva(
+      currentRobot.mbc().bodyPosW[currentRobot.bodyIndexByName(fs.parentBody())],
+      currentRobot.mbc().bodyVelW[currentRobot.bodyIndexByName(fs.parentBody())], true);
+
+  // kinematics of the frame of the force sensor in the world frame
+  so::kine::Kinematics worldSensorKine = worldBodyKine * bodyContactSensorKine;
+
+  if(KoContactsManager().getContactsDetection() == KoContactsManager::ContactsDetection::fromThreshold)
+  {
+    // If the contact is detecting using thresholds, we will then consider the sensor frame as
+    // the contact surface frame directly.
+    worldContactKine = worldSensorKine;
+    updateContactForceMeasurement(contact, measuredWrench);
+  }
+  else // the kinematics of the contacts are the ones of the surface, but we must transport the measured wrench
+  {
+    // pose of the surface in the world / floating base's frame
+    sva::PTransformd worldSurfacePose = currentRobot.surfacePose(contact.surfaceName());
+    // Kinematics of the surface in the world / floating base's frame
+    worldContactKine = kinematicsTools::poseFromSva(worldSurfacePose, so::kine::Kinematics::Flags::vel);
+
+    contact.surfaceSensorKine_ = worldContactKine.getInverse() * worldSensorKine;
+    // expressing the force measurement in the frame of the surface
+    updateContactForceMeasurement(contact, contact.surfaceSensorKine_, measuredWrench);
+  }
+
+  return worldContactKine;
+}
+
+const so::kine::Kinematics MCKineticsObserver::getContactWorldKinematics(KoContactWithSensor & contact,
+                                                                         const mc_rbdyn::Robot & currentRobot,
+                                                                         const mc_rbdyn::ForceSensor & fs)
+{
+  /*
+  Can be used with inputRobot, a virtual robot corresponding to the real robot whose floating base's frame is
+  superimposed with the world frame. Getting kinematics associated to the inputRobot inside the world frame is the same
+  as getting the same kinematics of the real robot inside the frame of its floating base, which is needed for the inputs
+  of the Kinetics Observer. This allows to use the basic mc_rtc functions directly giving kinematics in the world frame
+  and not do the conversion: initial frame -> world + world -> floating base as the latter is zero.
+  */
+
+  so::kine::Kinematics worldContactKine;
+
+  const sva::PTransformd & bodyContactSensorPose = fs.X_p_f();
+  so::kine::Kinematics bodyContactSensorKine =
+      kinematicsTools::poseFromSva(bodyContactSensorPose, so::kine::Kinematics::Flags::vel);
+
+  // kinematics of the sensor's parent body in the world frame
+  so::kine::Kinematics worldBodyKine = kinematicsTools::poseAndVelFromSva(
+      currentRobot.mbc().bodyPosW[currentRobot.bodyIndexByName(fs.parentBody())],
+      currentRobot.mbc().bodyVelW[currentRobot.bodyIndexByName(fs.parentBody())], true);
+
+  so::kine::Kinematics worldSensorKine = worldBodyKine * bodyContactSensorKine;
+
+  if(KoContactsManager().getContactsDetection() == KoContactsManager::ContactsDetection::fromThreshold)
+  {
+    // If the contact is detecting using thresholds, we will then consider the sensor frame as
+    // the contact surface frame directly.
+    worldContactKine = worldSensorKine;
+  }
+  else // the kinematics of the contacts are the ones of the surface.
+  {
+    // pose of the surface in the world / floating base's frame
+    sva::PTransformd worldSurfacePose = currentRobot.surfacePose(contact.surfaceName());
+    // Kinematics of the surface in the world / floating base's frame
+    worldContactKine = kinematicsTools::poseFromSva(worldSurfacePose, so::kine::Kinematics::Flags::vel);
+  }
+
+  return worldContactKine;
+}
+
+void MCKineticsObserver::updateContactForceMeasurement(KoContactWithSensor & contact,
+                                                       so::kine::Kinematics surfaceSensorKine,
+                                                       const sva::ForceVecd & measuredWrench)
+{
+  // expressing the force measurement in the frame of the surface
+  contact.contactWrenchVector_.segment<3>(0) = surfaceSensorKine.orientation * measuredWrench.force();
+
+  // expressing the torque measurement in the frame of the surface
+  contact.contactWrenchVector_.segment<3>(3) =
+      surfaceSensorKine.orientation * measuredWrench.moment()
+      + surfaceSensorKine.position().cross(contact.contactWrenchVector_.segment<3>(0));
+}
+
+void MCKineticsObserver::updateContactForceMeasurement(KoContactWithSensor & contact,
+                                                       const sva::ForceVecd & measuredWrench)
+{
+  // If the contact is detecting using thresholds, we will then consider the sensor frame as
+  // the contact surface frame directly.
+  contact.contactWrenchVector_.segment<3>(0) = measuredWrench.force(); // retrieving the force measurement
+  contact.contactWrenchVector_.segment<3>(3) = measuredWrench.moment(); // retrieving the torque measurement
+}
+
+void MCKineticsObserver::getOdometryWorldContactRest(const mc_control::MCController & ctl,
+                                                     KoContactWithSensor & contact,
+                                                     so::kine::Kinematics & worldContactKineRef)
+{
+  const auto & robot = ctl.robot(robot_);
+  if(!contact.sensorEnabled_)
+  {
+    mc_rtc::log::info("The sensor is disabled but is required for the odometry. It will be used for the odometry "
+                      "but not in the correction made by the Kinetics Observer.");
+  }
+  const so::Vector3 & contactForceMeas = contact.contactWrenchVector_.segment<3>(0); // retrieving the force measurement
+  const so::Vector3 & contactTorqueMeas =
+      contact.contactWrenchVector_.segment<3>(3); // retrieving the torque measurement
+
+  // we get the kinematics of the contact in the real world from the ones of the centroid estimated by the Kinetics
+  // Observer. These kinematics are not the reference kinematics of the contact as they take into account the
+  // visco-elastic model of the contacts.
+  const so::kine::Kinematics worldContactKine = observer_.getGlobalKinematicsOf(contact.fbContactKine_);
+
+  // we get the reference position of the contact by removing the contribution of the visco-elastic model
+  worldContactKineRef.position =
+      worldContactKine.orientation.toMatrix3() * linStiffness_.inverse()
+          * (contactForceMeas
+             + worldContactKine.orientation.toMatrix3().transpose() * linDamping_ * worldContactKine.linVel())
+      + worldContactKine.position();
+
+  /* We get the reference orientation of the contact by removing the contribution of the visco-elastic model */
+  // difference between the reference orientation and the real one, obtained from the visco-elastic model
+  so::Vector3 flexRotDiff =
+      -2 * worldContactKine.orientation.toMatrix3() * angStiffness_.inverse()
+      * (contactTorqueMeas
+         + worldContactKine.orientation.toMatrix3().transpose() * angDamping_ * worldContactKine.angVel());
+
+  // axis of the rotation
+  so::Vector3 flexRotAxis = flexRotDiff / flexRotDiff.norm();
+
+  double diffNorm = flexRotDiff.norm() / 2;
+
+  if(diffNorm > 1.0) { diffNorm = 1.0; }
+  else if(diffNorm < -1.0) { diffNorm = -1.0; }
+
+  double flexRotAngle = std::asin(diffNorm);
+
+  // angle axis representation of the rotation due to the visco-elastic model
+  Eigen::AngleAxisd flexRotAngleAxis(flexRotAngle, flexRotAxis);
+  // matrix representation of the rotation due to the visco-elastic model
+  so::Matrix3 flexRotMatrix = so::kine::Orientation(flexRotAngleAxis).toMatrix3();
+  worldContactKineRef.orientation = so::Matrix3(flexRotMatrix.transpose() * worldContactKine.orientation.toMatrix3());
+
+  if(odometryType_ == measurements::flatOdometry) // if true, the position odometry is made only along the x and y axis,
+                                                  // the position along z is assumed to be the one of the control robot
+  {
+    // kinematics of the contact of the control robot in the world frame
+    so::kine::Kinematics worldContactKineControl =
+        getContactWorldKinematics(contact, robot, robot.forceSensor(contact.forceSensorName()));
+
+    // the reference altitude of the contact is the one in the control robot
+    worldContactKineRef.position()(2) = worldContactKineControl.position()(2);
+  }
+}
+
+void MCKineticsObserver::updateContact(const mc_control::MCController & ctl,
+                                       const int & contactIndex,
+                                       mc_rtc::Logger & logger)
+{
+  /*
+  Uses the inputRobot, a virtual robot corresponding to the real robot whose floating base's frame is superimposed with
+  the world frame. Getting kinematics associated to the inputRobot inside the world frame is the same as getting the
+  same kinematics of the real robot inside the frame of its floating base, which is needed for the inputs of the
+  Kinetics Observer. This allows to use the basic mc_rtc functions directly giving kinematics in the world frame and not
+  do the conversion: initial frame -> world + world -> floating base as the latter is zero.
+  */
+  auto & inputRobot = my_robots_->robot("inputRobot");
+
+  const auto & robot = ctl.robot(robot_);
+  KoContactWithSensor & contact = contactsManager_.contactWithSensor(contactIndex);
+
+  sva::ForceVecd measuredWrench = robot.forceSensor(contact.forceSensorName()).wrenchWithoutGravity(inputRobot);
+  const mc_rbdyn::ForceSensor & forceSensor = robot.forceSensor(contact.forceSensorName());
+
+  // As used on input robot, returns the kinematics of the contact in the frame of the floating base. Also expresses the
+  // measured wrench in the frame of the contact.
+  contact.fbContactKine_ = getContactWorldKinematicsAndWrench(contact, inputRobot, forceSensor, measuredWrench);
+
+  switch(contact.wasAlreadySet_)
+  {
+    // the contact already exists, it is updated
+    case true:
+      if(contact.sensorEnabled_) // the force sensor attached to the contact is used in the correction by the
+                                 // Kinetics Observer.
+      {
+        observer_.updateContactWithWrenchSensor(contact.contactWrenchVector_, contactSensorCovariance_,
+                                                contact.fbContactKine_, contactIndex);
+      }
+      else { observer_.updateContactWithNoSensor(contact.fbContactKine_, contactIndex); }
+
+      if(withDebugLogs_)
+      {
+        if(contact.sensorEnabled_ && !contact.sensorWasEnabled_)
+        {
+          addContactMeasurementsLogEntries(logger, contactIndex);
+          contact.sensorWasEnabled_ = true;
+        }
+        if(!contact.sensorEnabled_ && contact.sensorWasEnabled_)
+        {
+          removeContactMeasurementsLogEntries(logger, contactIndex);
+          contact.sensorWasEnabled_ = false;
+        }
+      }
+      break;
+
+    // the contact doesn't exist yet, it is updated
+    case false:
+      // reference of the contact in the world / floating base of the input robot
+      so::kine::Kinematics worldContactKineRef;
+
+      if(odometryType_ != measurements::None) // the Kinetics Observer performs odometry. The estimated state is used to
+                                              // provide the new contacts references.
+      {
+        getOdometryWorldContactRest(ctl, contact, worldContactKineRef);
+      }
+      else // we don't perform odometry, the reference pose of the contact is its pose in the control robot
+      {
+        worldContactKineRef = getContactWorldKinematics(contact, robot, forceSensor);
+      }
+
+      if(observer_.getNumberOfSetContacts() > 0) // The initial covariance on the pose of the contact depending on
+                                                 // whether another contact is already set or not
+      {
+        observer_.addContact(worldContactKineRef, contactInitCovarianceNewContacts_, contactProcessCovariance_,
+                             contactIndex, linStiffness_, linDamping_, angStiffness_, angDamping_);
+      }
+      else
+      {
+        observer_.addContact(worldContactKineRef, contactInitCovarianceFirstContacts_, contactProcessCovariance_,
+                             contactIndex, linStiffness_, linDamping_, angStiffness_, angDamping_);
+      }
+      if(contact.sensorEnabled_) // checks if the sensor is used in the correction of the Kinetics Observer
+                                 // or not
+      {
+        // we update the measurements of the sensor and the input kinematics of the contact in the user /
+        // floating base's frame
+        observer_.updateContactWithWrenchSensor(contact.contactWrenchVector_, contactSensorCovariance_,
+                                                contact.fbContactKine_, contactIndex);
+      }
+      else
+      {
+        // we update the input kinematics of the contact in the user / floating base's frame
+        observer_.updateContactWithNoSensor(contact.fbContactKine_, contactIndex);
+      }
+
+      if(withDebugLogs_) { addContactLogEntries(logger, contactIndex); }
+      break;
+  }
+}
+
+void MCKineticsObserver::updateContacts(
+    const mc_control::MCController & ctl,
+    const measurements::ContactsManager<KoContactWithSensor, measurements::ContactWithoutSensor>::ContactsSet &
+        updatedContactsIndexes,
+    mc_rtc::Logger & logger)
+{
+  for(const auto & updatedContactIndex : updatedContactsIndexes) { updateContact(ctl, updatedContactIndex, logger); }
+  // List of the contact that were set on last iteration but are not set anymore on the current one
+  for(const int & removedContactIndex : contactsManager_.removedContacts())
+  {
+    observer_.removeContact(removedContactIndex);
+
+    if(withDebugLogs_)
+    {
+      removeContactLogEntries(logger, removedContactIndex);
+      removeContactMeasurementsLogEntries(logger, removedContactIndex);
+    }
+  }
+
+  unsigned nbContacts = static_cast<unsigned>(updatedContactsIndexes.size());
+  if(debug_) { mc_rtc::log::info("nbContacts = {}", nbContacts); }
+}
+
+void MCKineticsObserver::mass(double mass)
+{
+  mass_ = mass;
+  observer_.setMass(mass);
+}
+
+///////////////////////////////////////////////////////////////////////
+/// -------------------------------Logs--------------------------------
+///////////////////////////////////////////////////////////////////////
+
+void MCKineticsObserver::addToLogger(const mc_control::MCController & ctl,
+                                     mc_rtc::Logger & logger,
+                                     const std::string & category)
+{
+  logger.addLogEntry(category + "_mcko_fb_posW", [this]() -> sva::PTransformd & { return X_0_fb_; });
+  logger.addLogEntry(category + "_mcko_fb_velW", [this]() -> sva::MotionVecd & { return v_fb_0_; });
+  logger.addLogEntry(category + "_mcko_fb_accW", [this]() -> sva::MotionVecd & { return a_fb_0_; });
+
+  logger.addLogEntry(category + "_mcko_fb_yaw",
+                     [this]() -> double { return -so::kine::rotationMatrixToYawAxisAgnostic(X_0_fb_.rotation()); });
+
+  logger.addLogEntry(category + "_constants_mass", [this]() -> double { return observer_.getMass(); });
+
+  logger.addLogEntry(category + "_constants_forceThreshold", [this]() -> double { return contactDetectionThreshold_; });
+  logger.addLogEntry(category + "_debug_estimationState",
+                     [this]() -> std::string
+                     {
+                       switch(estimationState_)
+                       {
+                         case noIssue:
+                           return "noIssue";
+                           break;
+                         case invincibilityFrame:
+                           return "invincibilityFrame";
+                           break;
+                         case errorDetected:
+                           return "errorDetected";
+                           break;
+                       }
+                       return "default";
+                     });
+  logger.addLogEntry(category + "_debug_OdometryType",
+                     [this]() -> std::string
+                     {
+                       switch(odometryType_)
+                       {
+                         case measurements::flatOdometry:
+                           return "flatOdometry";
+                           break;
+                         case measurements::odometry6d:
+                           return "6dOdometry";
+                           break;
+                         case measurements::None:
+                           return "None";
+                           break;
+                       }
+                       return "default";
+                     });
+
+  /* Plots of the updated state */
+  kinematicsTools::addToLogger(globalCentroidKinematics_, logger, observerName_ + "_globalWorldCentroidState");
+  logger.addLogEntry(observerName_ + "_globalWorldCentroidState_positionW_",
+                     [this]() -> Eigen::Vector3d { return globalCentroidKinematics_.position(); });
+  logger.addLogEntry(observerName_ + "_globalWorldCentroidState_linVelW",
+                     [this]() -> Eigen::Vector3d { return globalCentroidKinematics_.linVel(); });
+  logger.addLogEntry(observerName_ + "_globalWorldCentroidState_linAccW",
+                     [this]() -> Eigen::Vector3d { return globalCentroidKinematics_.linAcc(); });
+  logger.addLogEntry(observerName_ + "_globalWorldCentroidState_oriW",
+                     [this]() -> Eigen::Quaternion<double>
+                     { return globalCentroidKinematics_.orientation.inverse().toQuaternion(); });
+  logger.addLogEntry(observerName_ + "_globalWorldCentroidState_angVelW",
+                     [this]() -> Eigen::Vector3d { return globalCentroidKinematics_.angVel(); });
+  logger.addLogEntry(observerName_ + "_globalWorldCentroidState_angAccW",
+                     [this]() -> Eigen::Vector3d { return globalCentroidKinematics_.angAcc(); });
+  for(const auto & imu : IMUs_)
+  {
+    logger.addLogEntry(observerName_ + "_globalWorldCentroidState_gyroBias_" + imu.name(),
+                       [this, imu]() -> Eigen::Vector3d
+                       {
+                         return observer_.getCurrentStateVector().segment(
+                             observer_.gyroBiasIndex(mapIMUs_.getNumFromName(imu.name())), observer_.sizeGyroBias);
+                       });
+  }
+  logger.addLogEntry(
+      observerName_ + "_globalWorldCentroidState_extForceCentr",
+      [this]() -> Eigen::Vector3d
+      { return observer_.getCurrentStateVector().segment(observer_.unmodeledForceIndex(), observer_.sizeForce); });
+
+  logger.addLogEntry(
+      observerName_ + "_globalWorldCentroidState_extTorqueCentr",
+      [this]() -> Eigen::Vector3d
+      { return observer_.getCurrentStateVector().segment(observer_.unmodeledTorqueIndex(), observer_.sizeTorque); });
+
+  /* Inputs */
+  logger.addLogEntry(observerName_ + "_inputs_additionalWrench_Force",
+                     [this]() -> Eigen::Vector3d
+                     { return observer_.getAdditionalWrench().segment(0, observer_.sizeForce); });
+  logger.addLogEntry(observerName_ + "_inputs_additionalWrench_Torque",
+                     [this]() -> Eigen::Vector3d
+                     { return observer_.getAdditionalWrench().segment(observer_.sizeForce, observer_.sizeTorque); });
+
+  /* State covariances */
+  logger.addLogEntry(observerName_ + "_stateCovariances_positionW_",
+                     [this]() -> Eigen::Vector3d
+                     {
+                       return observer_.getEKF()
+                           .getStateCovariance()
+                           .block(observer_.posIndexTangent(), observer_.posIndexTangent(), observer_.sizePosTangent,
+                                  observer_.sizePosTangent)
+                           .diagonal();
+                     });
+  logger.addLogEntry(observerName_ + "_stateCovariances_orientationW_",
+                     [this]() -> Eigen::Vector3d
+                     {
+                       return observer_.getEKF()
+                           .getStateCovariance()
+                           .block(observer_.oriIndexTangent(), observer_.oriIndexTangent(), observer_.sizeOriTangent,
+                                  observer_.sizeOriTangent)
+                           .diagonal();
+                     });
+  logger.addLogEntry(observerName_ + "_stateCovariances_linVelW_",
+                     [this]() -> Eigen::Vector3d
+                     {
+                       return observer_.getEKF()
+                           .getStateCovariance()
+                           .block(observer_.linVelIndexTangent(), observer_.linVelIndexTangent(),
+                                  observer_.sizeLinVelTangent, observer_.sizeLinVelTangent)
+                           .diagonal();
+                     });
+  logger.addLogEntry(observerName_ + "_stateCovariances_angVelW_",
+                     [this]() -> Eigen::Vector3d
+                     {
+                       return observer_.getEKF()
+                           .getStateCovariance()
+                           .block(observer_.angVelIndexTangent(), observer_.angVelIndexTangent(),
+                                  observer_.sizeAngVelTangent, observer_.sizeAngVelTangent)
+                           .diagonal();
+                     });
+
+  for(const auto & imu : IMUs_)
+  {
+    logger.addLogEntry(observerName_ + "_stateCovariances_gyroBias_" + imu.name(),
+                       [this, imu]() -> Eigen::Vector3d
+                       {
+                         return observer_.getEKF()
+                             .getStateCovariance()
+                             .block(observer_.gyroBiasIndexTangent(mapIMUs_.getNumFromName(imu.name())),
+                                    observer_.gyroBiasIndexTangent(mapIMUs_.getNumFromName(imu.name())),
+                                    observer_.sizeGyroBiasTangent, observer_.sizeGyroBiasTangent)
+                             .diagonal();
+                       });
+  }
+
+  logger.addLogEntry(observerName_ + "_stateCovariances_extForce_",
+                     [this]() -> Eigen::Vector3d
+                     {
+                       return observer_.getEKF()
+                           .getStateCovariance()
+                           .block(observer_.unmodeledForceIndexTangent(), observer_.unmodeledForceIndexTangent(),
+                                  observer_.sizeForceTangent, observer_.sizeForceTangent)
+                           .diagonal();
+                     });
+  logger.addLogEntry(observerName_ + "_stateCovariances_extTorque_",
+                     [this]() -> Eigen::Vector3d
+                     {
+                       return observer_.getEKF()
+                           .getStateCovariance()
+                           .block(observer_.unmodeledTorqueIndexTangent(), observer_.unmodeledTorqueIndexTangent(),
+                                  observer_.sizeTorqueTangent, observer_.sizeTorqueTangent)
+                           .diagonal();
+                     });
+
+  if(ctl.realRobot().hasBody("LeftFoot"))
+  {
+    logger.addLogEntry(observerName_ + "_realRobot_LeftFoot",
+                       [&ctl]() { return ctl.realRobot().frame("LeftFoot").position(); });
+  }
+
+  if(ctl.realRobot().hasBody("RightFoot"))
+  {
+    logger.addLogEntry(observerName_ + "_realRobot_RightFoot",
+                       [&ctl]() { return ctl.realRobot().frame("RightFoot").position(); });
+  }
+
+  if(ctl.realRobot().hasBody("LeftHand"))
+  {
+    logger.addLogEntry(observerName_ + "_realRobot_LeftHand",
+                       [&ctl]() { return ctl.realRobot().frame("LeftHand").position(); });
+  }
+  if(ctl.realRobot().hasBody("RightHand"))
+  {
+    logger.addLogEntry(observerName_ + "_realRobot_RightHand",
+                       [&ctl]() { return ctl.realRobot().frame("RightHand").position(); });
+  }
+  if(ctl.robot().hasBody("LeftFoot"))
+  {
+    logger.addLogEntry(observerName_ + "_ctlRobot_LeftFoot",
+                       [&ctl]() { return ctl.robot().frame("LeftFoot").position(); });
+  }
+  if(ctl.robot().hasBody("RightFoot"))
+  {
+    logger.addLogEntry(observerName_ + "_ctlRobot_RightFoot",
+                       [&ctl]() { return ctl.robot().frame("RightFoot").position(); });
+  }
+
+  if(ctl.robot().hasBody("LeftHand"))
+  {
+    logger.addLogEntry(observerName_ + "_ctlRobot_LeftHand",
+                       [&ctl]() { return ctl.robot().frame("LeftHand").position(); });
+  }
+
+  if(ctl.robot().hasBody("RightHand"))
+  {
+    logger.addLogEntry(observerName_ + "_ctlRobot_RightHand",
+                       [&ctl]() { return ctl.robot().frame("RightHand").position(); });
+  }
+
+  /* Plots of the inputs */
+
+  logger.addLogEntry(observerName_ + "_inputs_angularMomentum",
+                     [this]() -> Eigen::Vector3d { return observer_.getAngularMomentum()(); });
+  logger.addLogEntry(observerName_ + "_inputs_angularMomentumDot",
+                     [this]() -> Eigen::Vector3d { return observer_.getAngularMomentumDot()(); });
+  logger.addLogEntry(observerName_ + "_inputs_com",
+                     [this]() -> Eigen::Vector3d { return observer_.getCenterOfMass()(); });
+  logger.addLogEntry(observerName_ + "_inputs_comDot",
+                     [this]() -> Eigen::Vector3d { return observer_.getCenterOfMassDot()(); });
+  logger.addLogEntry(observerName_ + "_inputs_comDotDot",
+                     [this]() -> Eigen::Vector3d { return observer_.getCenterOfMassDotDot()(); });
+  logger.addLogEntry(observerName_ + "_inputs_inertiaMatrix",
+                     [this]() -> Eigen::Vector6d
+                     {
+                       so::Vector6 inertia;
+                       inertia.segment<3>(0) = observer_.getInertiaMatrix()().diagonal();
+                       inertia.segment<2>(3) = observer_.getInertiaMatrix()().block<1, 2>(0, 1);
+                       inertia(5) = observer_.getInertiaMatrix()()(1, 2);
+                       return inertia;
+                     });
+
+  logger.addLogEntry(observerName_ + "_inputs_inertiaMatrixDot",
+                     [this]() -> Eigen::Vector6d
+                     {
+                       so::Vector6 inertiaDot;
+                       inertiaDot.segment<3>(0) = observer_.getInertiaMatrixDot()().diagonal();
+                       inertiaDot.segment<2>(3) = observer_.getInertiaMatrixDot()().block<1, 2>(0, 1);
+                       inertiaDot(5) = observer_.getInertiaMatrixDot()()(1, 2);
+                       return inertiaDot;
+                     });
+
+  /* Plots of the measurements */
+  {
+    for(const auto & imu : IMUs_)
+    {
+      logger.addLogEntry(observerName_ + "_measurements_gyro_" + imu.name() + "_measured",
+                         [this, imu]() -> Eigen::Vector3d
+                         {
+                           return observer_.getEKF().getLastMeasurement().segment(
+                               observer_.getIMUMeasIndexByNum(mapIMUs_.getNumFromName(imu.name()))
+                                   + observer_.sizeAcceleroSignal,
+                               observer_.sizeGyroBias);
+                         });
+      logger.addLogEntry(observerName_ + "_measurements_gyro_" + imu.name() + "_predicted",
+                         [this, imu]() -> Eigen::Vector3d
+                         {
+                           return observer_.getEKF().getLastPredictedMeasurement().segment(
+                               observer_.getIMUMeasIndexByNum(mapIMUs_.getNumFromName(imu.name()))
+                                   + observer_.sizeAcceleroSignal,
+                               observer_.sizeGyroBias);
+                         });
+      logger.addLogEntry(observerName_ + "_measurements_gyro_" + imu.name() + "_corrected",
+                         [this, imu]() -> Eigen::Vector3d
+                         {
+                           return correctedMeasurements_.segment(
+                               observer_.getIMUMeasIndexByNum(mapIMUs_.getNumFromName(imu.name()))
+                                   + observer_.sizeAcceleroSignal,
+                               observer_.sizeGyroBias);
+                         });
+
+      logger.addLogEntry(observerName_ + "_measurements_accelerometer_" + imu.name() + "_measured",
+                         [this, imu]() -> Eigen::Vector3d
+                         {
+                           return observer_.getEKF().getLastMeasurement().segment(
+                               observer_.getIMUMeasIndexByNum(mapIMUs_.getNumFromName(imu.name())),
+                               observer_.sizeAcceleroSignal);
+                         });
+      logger.addLogEntry(observerName_ + "_measurements_accelerometer_" + imu.name() + "_predicted",
+                         [this, imu]() -> Eigen::Vector3d
+                         {
+                           return observer_.getEKF().getLastPredictedMeasurement().segment(
+                               observer_.getIMUMeasIndexByNum(mapIMUs_.getNumFromName(imu.name())),
+                               observer_.sizeAcceleroSignal);
+                         });
+      logger.addLogEntry(observerName_ + "_measurements_accelerometer_" + imu.name() + "_corrected",
+                         [this, imu]() -> Eigen::Vector3d
+                         {
+                           return correctedMeasurements_.segment(
+                               observer_.getIMUMeasIndexByNum(mapIMUs_.getNumFromName(imu.name())),
+                               observer_.sizeAcceleroSignal);
+                         });
+    }
+
+    logger.addLogEntry(observerName_ + "_measurements_absoluteOri_measured",
+                       [this]() -> Eigen::Quaterniond
+                       {
+                         so::kine::Orientation ori;
+                         ori.fromVector4(observer_.getEKF().getLastMeasurement().tail(4));
+
+                         return ori.toQuaternion().inverse();
+                       });
+    logger.addLogEntry(observerName_ + "_measurements_absoluteOri_corrected",
+                       [this]() -> Eigen::Quaterniond
+                       {
+                         so::kine::Orientation ori;
+                         ori.fromVector4(correctedMeasurements_.tail(4));
+
+                         return ori.toQuaternion().inverse();
+                       });
+    logger.addLogEntry(observerName_ + "_measurements_absoluteOri_predicted",
+                       [this]() -> Eigen::Quaterniond
+                       {
+                         so::kine::Orientation ori;
+                         ori.fromVector4(observer_.getEKF().getLastPredictedMeasurement().tail(4));
+
+                         return ori.toQuaternion().inverse();
+                       });
+  }
+
+  /* Plots of the innovation */
+  logger.addLogEntry(
+      observerName_ + "_innovation_positionW_",
+      [this]() -> Eigen::Vector3d
+      { return observer_.getEKF().getInnovation().segment(observer_.posIndexTangent(), observer_.sizePosTangent); });
+  logger.addLogEntry(observerName_ + "_innovation_linVelW_",
+                     [this]() -> Eigen::Vector3d {
+                       return observer_.getEKF().getInnovation().segment(observer_.linVelIndexTangent(),
+                                                                         observer_.sizeLinVelTangent);
+                     });
+  logger.addLogEntry(
+      observerName_ + "_innovation_oriW_",
+      [this]() -> Eigen::Vector3d
+      { return observer_.getEKF().getInnovation().segment(observer_.oriIndexTangent(), observer_.sizeOriTangent); });
+  logger.addLogEntry(observerName_ + "_innovation_angVelW_",
+                     [this]() -> Eigen::Vector3d {
+                       return observer_.getEKF().getInnovation().segment(observer_.angVelIndexTangent(),
+                                                                         observer_.sizeAngVelTangent);
+                     });
+  for(const auto & imu : IMUs_)
+  {
+    logger.addLogEntry(observerName_ + "_innovation_gyroBias_" + imu.name(),
+                       [this, imu]() -> Eigen::Vector3d
+                       {
+                         return observer_.getEKF().getInnovation().segment(
+                             observer_.gyroBiasIndexTangent(mapIMUs_.getNumFromName(imu.name())),
+                             observer_.sizeGyroBias);
+                       });
+  }
+  logger.addLogEntry(observerName_ + "_innovation_unmodeledForce_",
+                     [this]() -> Eigen::Vector3d
+                     {
+                       return observer_.getEKF().getInnovation().segment(observer_.unmodeledForceIndexTangent(),
+                                                                         observer_.sizeForceTangent);
+                     });
+  logger.addLogEntry(observerName_ + "_innovation_unmodeledTorque_",
+                     [this]() -> Eigen::Vector3d
+                     {
+                       return observer_.getEKF().getInnovation().segment(observer_.unmodeledTorqueIndexTangent(),
+                                                                         observer_.sizeTorqueTangent);
+                     });
+
+  logger.addLogEntry(observerName_ + "_debug_worldInputRobotKine_position",
+                     [this]() -> Eigen::Vector3d { return my_robots_->robot("inputRobot").posW().translation(); });
+  logger.addLogEntry(observerName_ + "_debug_worldInputRobotKine_orientation",
+                     [this]() -> Eigen::Quaternion<double>
+                     {
+                       return so::kine::Orientation(so::Matrix3(my_robots_->robot("inputRobot").posW().rotation()))
+                           .inverse()
+                           .toQuaternion();
+                     });
+  logger.addLogEntry(observerName_ + "_debug_worldInputRobotKine_linVel",
+                     [this]() -> Eigen::Vector3d { return my_robots_->robot("inputRobot").velW().linear(); });
+  logger.addLogEntry(observerName_ + "_debug_worldInputRobotKine_angVel",
+                     [this]() -> Eigen::Vector3d { return my_robots_->robot("inputRobot").velW().angular(); });
+  logger.addLogEntry(observerName_ + "_debug_worldInputRobotKine_linAcc",
+                     [this]() -> Eigen::Vector3d { return my_robots_->robot("inputRobot").accW().linear(); });
+  logger.addLogEntry(observerName_ + "_debug_worldInputRobotKine_angAcc",
+                     [this]() -> Eigen::Vector3d { return my_robots_->robot("inputRobot").accW().angular(); });
+
+  for(auto & contactWithSensor : contactsManager_.contactsWithSensors())
+  {
+    const measurements::ContactWithSensor & contact = contactWithSensor.second;
+    logger.addLogEntry(observerName_ + "_debug_wrenchesInCentroid_" + contact.getName() + "_force",
+                       [this, contact]() -> Eigen::Vector3d { return contact.wrenchInCentroid_.segment<3>(0); });
+    logger.addLogEntry(observerName_ + "_debug_wrenchesInCentroid_" + contact.getName() + "_torque",
+                       [this, contact]() -> Eigen::Vector3d { return contact.wrenchInCentroid_.segment<3>(3); });
+    logger.addLogEntry(observerName_ + "_debug_wrenchesInCentroid_" + contact.getName() + "_forceWithUnmodeled",
+                       [this, contact]() -> Eigen::Vector3d
+                       {
+                         return observer_.getCurrentStateVector().segment(observer_.unmodeledForceIndex(),
+                                                                          observer_.sizeForce)
+                                + contact.wrenchInCentroid_.segment<3>(0);
+                       });
+    logger.addLogEntry(observerName_ + "_debug_wrenchesInCentroid_" + contact.getName() + "_torqueWithUnmodeled",
+                       [this, contact]() -> Eigen::Vector3d
+                       {
+                         return observer_.getCurrentStateVector().segment(observer_.unmodeledTorqueIndex(),
+                                                                          observer_.sizeTorque)
+                                + contact.wrenchInCentroid_.segment<3>(3);
+                       });
+  }
+
+  for(const auto & imu : IMUs_)
+  {
+    logger.addLogEntry(observerName_ + "_debug_gyroBias_" + imu.name(),
+                       [this, imu]() -> Eigen::Vector3d { return mapIMUs_(imu.name()).gyroBias; });
+  }
+}
+
+void MCKineticsObserver::removeFromLogger(mc_rtc::Logger & logger, const std::string & category)
+{
+  logger.removeLogEntry(category + "_posW");
+  logger.removeLogEntry(category + "_velW");
+  logger.removeLogEntry(category + "_mass");
+  logger.removeLogEntry(category + "_flexStiffness");
+  logger.removeLogEntry(category + "_flexDamping");
+}
+
+void MCKineticsObserver::changeOdometryType(const mc_control::MCController & ctl, const std::string & newOdometryType)
+{
+  OdometryType prevOdometryType = odometryType_;
+  if(newOdometryType == "flatOdometry") { odometryType_ = measurements::flatOdometry; }
+  else if(newOdometryType == "6dOdometry") { odometryType_ = measurements::odometry6d; }
+
+  // if the type didn't change, we stop the function here
+  if(odometryType_ == prevOdometryType) { return; }
+
+  mc_rtc::log::info("[{}]: Odometry mode changed to: {}", observerName_, newOdometryType);
+
+  // if the Tilt Observer is used as a backup, its odometry must also be changed
+  if(ctl.datastore().has("changeTiltOdometryType"))
+  {
+    ctl.datastore().call<>("changeTiltOdometryType", newOdometryType);
+  }
+}
+
+void MCKineticsObserver::addToGUI(const mc_control::MCController & ctl,
+                                  mc_rtc::gui::StateBuilder & gui,
+                                  const std::vector<std::string> & category)
+{
+  using namespace mc_rtc::gui;
+  // clang-format off
+  gui.addElement(category,
+    mc_state_observation::gui::make_input_element("Accel Covariance", acceleroSensorCovariance_(0,0)),
+    mc_state_observation::gui::make_input_element("Force Covariance", contactSensorCovariance_(0,0)),
+    mc_state_observation::gui::make_input_element("Gyro Covariance", gyroSensorCovariance_(0,0)));
+
+  if(odometryType_ != measurements::None)
+  {
+    gui.addElement({observerName_, "Odometry"}, mc_rtc::gui::ComboInput(
+                                                                  "Choose from list", {"6dOdometry", "flatOdometry"},
+                                                                  [this]() -> std::string {
+                                                                    if(odometryType_ == measurements::flatOdometry)
+                                                                    {
+                                                                      return "flatOdometry";
+                                                                    }
+                                                                    else
+                                                                    {
+                                                                      return "6dOdometry";
+                                                                    }
+                                                                  },
+                                                                  [this, &ctl](const std::string & typeOfOdometry) {
+                                                                    changeOdometryType(ctl, typeOfOdometry);
+                                                                  }));
+  }
+  // clang-format on
+}
+
+void MCKineticsObserver::addContactLogEntries(mc_rtc::Logger & logger, const int & contactIndex)
+{
+  const std::string & contactName = contactsManager_.mapContacts_.getNameFromNum(contactIndex);
+  if(observer_.getContactIsSetByNum(contactIndex))
+  {
+    logger.addLogEntry(observerName_ + "_globalWorldCentroidState_contact_" + contactName + "_position",
+                       [this, contactIndex]() -> Eigen::Vector3d {
+                         return observer_.getCurrentStateVector().segment(observer_.contactPosIndex(contactIndex),
+                                                                          observer_.sizePos);
+                       });
+    logger.addLogEntry(observerName_ + "_globalWorldCentroidState_contact_" + contactName + "_orientation",
+                       [this, contactIndex]() -> Eigen::Quaternion<double>
+                       {
+                         so::kine::Orientation ori;
+                         return ori
+                             .fromVector4(observer_.getCurrentStateVector().segment(
+                                 observer_.contactOriIndex(contactIndex), observer_.sizeOri))
+                             .inverse()
+                             .toQuaternion();
+                       });
+    logger.addLogEntry(observerName_ + "_globalWorldCentroidState_contact_" + contactName + "_orientation_RollPitchYaw",
+                       [this, contactIndex]() -> so::Vector3
+                       {
+                         so::kine::Orientation ori;
+                         return so::kine::rotationMatrixToRollPitchYaw(
+                             ori.fromVector4(observer_.getCurrentStateVector().segment(
+                                                 observer_.contactOriIndex(contactIndex), observer_.sizeOri))
+                                 .toMatrix3());
+                       });
+    logger.addLogEntry(observerName_ + "_globalWorldCentroidState_contact_" + contactName + "_forces",
+                       [this, contactIndex]() -> Eigen::Vector3d {
+                         return observer_.getCurrentStateVector().segment(observer_.contactForceIndex(contactIndex),
+                                                                          observer_.sizeForce);
+                       });
+    logger.addLogEntry(observerName_ + "_globalWorldCentroidState_contact_" + contactName + "_torques",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       {
+                         return globalCentroidKinematics_.orientation.toMatrix3()
+                                * observer_.getCurrentStateVector().segment(observer_.contactTorqueIndex(contactIndex),
+                                                                            observer_.sizeTorque);
+                       });
+    logger.addLogEntry(observerName_ + "_stateCovariances_contact_" + contactName + "_position_",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       {
+                         return observer_.getEKF()
+                             .getStateCovariance()
+                             .block(observer_.contactPosIndexTangent(contactIndex),
+                                    observer_.contactPosIndexTangent(contactIndex), observer_.sizePosTangent,
+                                    observer_.sizePosTangent)
+                             .diagonal();
+                       });
+    logger.addLogEntry(observerName_ + "_stateCovariances_contact_" + contactName + "_orientation_",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       {
+                         return observer_.getEKF()
+                             .getStateCovariance()
+                             .block(observer_.contactOriIndexTangent(contactIndex),
+                                    observer_.contactOriIndexTangent(contactIndex), observer_.sizeOriTangent,
+                                    observer_.sizeOriTangent)
+                             .diagonal();
+                       });
+    logger.addLogEntry(observerName_ + "_stateCovariances_contact_" + contactName + "_Force_",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       {
+                         return observer_.getEKF()
+                             .getStateCovariance()
+                             .block(observer_.contactForceIndexTangent(contactIndex),
+                                    observer_.contactForceIndexTangent(contactIndex), observer_.sizeForceTangent,
+                                    observer_.sizeForceTangent)
+                             .diagonal();
+                       });
+    logger.addLogEntry(observerName_ + "_stateCovariances_contact_" + contactName + "_Torque_",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       {
+                         return observer_.getEKF()
+                             .getStateCovariance()
+                             .block(observer_.contactTorqueIndexTangent(contactIndex),
+                                    observer_.contactTorqueIndexTangent(contactIndex), observer_.sizeTorqueTangent,
+                                    observer_.sizeTorqueTangent)
+                             .diagonal();
+                       });
+
+    logger.addLogEntry(observerName_ + "_innovation_contact_" + contactName + "_position",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       {
+                         return observer_.getEKF().getInnovation().segment(
+                             observer_.contactPosIndexTangent(contactIndex), observer_.sizePos);
+                       });
+    logger.addLogEntry(observerName_ + "_innovation_contact_" + contactName + "_orientation",
+                       [this, contactIndex]() -> Eigen::Quaternion<double>
+                       {
+                         so::kine::Orientation ori;
+                         return ori
+                             .fromVector4(observer_.getEKF().getInnovation().segment(
+                                 observer_.contactOriIndexTangent(contactIndex), observer_.sizeOri))
+                             .inverse()
+                             .toQuaternion();
+                       });
+    logger.addLogEntry(observerName_ + "_innovation_contact_" + contactName + "_forces",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       {
+                         return observer_.getEKF().getInnovation().segment(
+                             observer_.contactForceIndexTangent(contactIndex), observer_.sizeForce);
+                       });
+    logger.addLogEntry(observerName_ + "_innovation_contact_" + contactName + "_torques",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       {
+                         return observer_.getEKF().getInnovation().segment(
+                             observer_.contactTorqueIndexTangent(contactIndex), observer_.sizeTorque);
+                       });
+
+    logger.addLogEntry(observerName_ + "_debug_contactWrench_Centroid_" + contactName + "_force",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       { return observer_.getCentroidContactWrench(contactIndex).segment(0, observer_.sizeForce); });
+
+    logger.addLogEntry(observerName_ + "_debug_contactWrench_Centroid_" + contactName + "_torque",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       { return observer_.getCentroidContactWrench(contactIndex).segment(3, observer_.sizeTorque); });
+
+    logger.addLogEntry(observerName_ + "_debug_contactPose_" + contactName + "_inputCentroidContactKine_position",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       { return observer_.getCentroidContactInputPose(contactIndex).position(); });
+
+    logger.addLogEntry(
+        observerName_ + "_debug_contactPose_" + contactName + "_inputCentroidContactKine_orientation",
+        [this, contactIndex]() -> Eigen::Quaternion<double>
+        { return observer_.getCentroidContactInputPose(contactIndex).orientation.inverse().toQuaternion(); });
+
+    logger.addLogEntry(observerName_ + "_debug_contactPose_" + contactName + "_worldContactPoseFromCentroid_position",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       { return observer_.getWorldContactPoseFromCentroid(contactIndex).position(); });
+
+    logger.addLogEntry(
+        observerName_ + "_debug_contactPose_" + contactName + "_worldContactPoseFromCentroid_orientation",
+        [this, contactIndex]() -> Eigen::Quaternion<double>
+        { return observer_.getWorldContactPoseFromCentroid(contactIndex).orientation.inverse().toQuaternion(); });
+
+    logger.addLogEntry(observerName_ + "_debug_contactPose_" + contactName + "_inputUserContactKine_position",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       { return observer_.getUserContactInputPose(contactIndex).position(); });
+
+    logger.addLogEntry(observerName_ + "_debug_contactPose_" + contactName + "_inputUserContactKine_orientation",
+                       [this, contactIndex]() -> Eigen::Quaternion<double> {
+                         return observer_.getUserContactInputPose(contactIndex).orientation.inverse().toQuaternion();
+                       });
+    logger.addLogEntry(observerName_ + "_debug_contactState_isSet_" + contactName,
+                       [this, contactIndex]() -> int
+                       { return int(contactsManager_.contactWithSensor(contactIndex).isSet_); });
+  }
+}
+
+void MCKineticsObserver::addContactMeasurementsLogEntries(mc_rtc::Logger & logger, const int & contactIndex)
+{
+  const std::string & contactName = contactsManager_.mapContacts_.getNameFromNum(contactIndex);
+  if(observer_.getContactIsSetByNum(contactIndex))
+  {
+    logger.addLogEntry(observerName_ + "_measurements_contacts_force_" + contactName + "_measured",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       {
+                         return observer_.getEKF().getLastMeasurement().segment(
+                             observer_.getContactMeasIndexByNum(contactIndex), observer_.sizeForce);
+                       });
+    logger.addLogEntry(observerName_ + "_measurements_contacts_force_" + contactName + "_predicted",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       {
+                         return observer_.getEKF().getLastPredictedMeasurement().segment(
+                             observer_.getContactMeasIndexByNum(contactIndex), observer_.sizeForce);
+                       });
+    logger.addLogEntry(observerName_ + "_measurements_contacts_force_" + contactName + "_corrected",
+                       [this, contactIndex]() -> Eigen::Vector3d {
+                         return correctedMeasurements_.segment(observer_.getContactMeasIndexByNum(contactIndex),
+                                                               observer_.sizeForce);
+                       });
+
+    logger.addLogEntry(observerName_ + "_measurements_contacts_torque_" + contactName + "_measured",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       {
+                         return observer_.getEKF().getLastMeasurement().segment(
+                             observer_.getContactMeasIndexByNum(contactIndex) + observer_.sizeForce,
+                             observer_.sizeTorque);
+                       });
+    logger.addLogEntry(observerName_ + "_measurements_contacts_torque_" + contactName + "_predicted",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       {
+                         return observer_.getEKF().getLastPredictedMeasurement().segment(
+                             observer_.getContactMeasIndexByNum(contactIndex) + observer_.sizeForce,
+                             observer_.sizeTorque);
+                       });
+    logger.addLogEntry(observerName_ + "_measurements_contacts_torque_" + contactName + "_corrected",
+                       [this, contactIndex]() -> Eigen::Vector3d
+                       {
+                         return correctedMeasurements_.segment(observer_.getContactMeasIndexByNum(contactIndex)
+                                                                   + observer_.sizeForce,
+                                                               observer_.sizeTorque);
+                       });
+  }
+}
+
+void MCKineticsObserver::removeContactLogEntries(mc_rtc::Logger & logger, const int & contactIndex)
+{
+  const std::string & contactName = contactsManager_.mapContacts_.getNameFromNum(contactIndex);
+  logger.removeLogEntry(observerName_ + "_globalWorldCentroidState_contact_" + contactName + "_position");
+  logger.removeLogEntry(observerName_ + "_globalWorldCentroidState_contact_" + contactName + "_position");
+  logger.removeLogEntry(observerName_ + "_globalWorldCentroidState_contact_" + contactName + "_orientation");
+  logger.removeLogEntry(observerName_ + "_globalWorldCentroidState_contact_" + contactName
+                        + "_orientation_RollPitchYaw");
+  logger.removeLogEntry(observerName_ + "_globalWorldCentroidState_contact_" + contactName + "_forces");
+  logger.removeLogEntry(observerName_ + "_globalWorldCentroidState_contact_" + contactName + "_torques");
+  logger.removeLogEntry(observerName_ + "_stateCovariances_contact_" + contactName + "_position_");
+  logger.removeLogEntry(observerName_ + "_stateCovariances_contact_" + contactName + "_orientation_");
+  logger.removeLogEntry(observerName_ + "_stateCovariances_contact_" + contactName + "_Force_");
+  logger.removeLogEntry(observerName_ + "_stateCovariances_contact_" + contactName + "_Torque_");
+
+  logger.removeLogEntry(observerName_ + "_predictedGlobalCentroidKinematics_contact_" + contactName + "_position");
+  logger.removeLogEntry(observerName_ + "_predictedGlobalCentroidKinematics_contact_" + contactName + "_orientation");
+  logger.removeLogEntry(observerName_ + "_predictedGlobalCentroidKinematics_contact_" + contactName + "_forces");
+  logger.removeLogEntry(observerName_ + "_predictedGlobalCentroidKinematics_contact_" + contactName + "_torques");
+
+  logger.removeLogEntry(observerName_ + "_innovation_contact_" + contactName + "_position");
+  logger.removeLogEntry(observerName_ + "_innovation_contact_" + contactName + "_orientation");
+  logger.removeLogEntry(observerName_ + "_innovation_contact_" + contactName + "_forces");
+  logger.removeLogEntry(observerName_ + "_innovation_contact_" + contactName + "_torques");
+
+  logger.removeLogEntry(observerName_ + "_debug_contactWrench_World_" + contactName + "_force");
+
+  logger.removeLogEntry(observerName_ + "_debug_contactWrench_World_" + contactName + "_torque");
+
+  logger.removeLogEntry(observerName_ + "_debug_contactWrench_Centroid_" + contactName + "_force");
+
+  logger.removeLogEntry(observerName_ + "_debug_contactWrench_Centroid_" + contactName + "_torque");
+
+  logger.removeLogEntry(observerName_ + "_debug_contactPose_" + contactName + "_inputWorldRef_position");
+
+  logger.removeLogEntry(observerName_ + "_debug_contactPose_" + contactName + "_inputWorldRef_orientation");
+
+  logger.removeLogEntry(observerName_ + "_debug_contactPose_" + contactName + "_inputCentroidContactKine_position");
+
+  logger.removeLogEntry(observerName_ + "_debug_contactPose_" + contactName + "_inputCentroidContactKine_orientation");
+
+  logger.removeLogEntry(observerName_ + "_debug_contactPose_" + contactName + "_worldContactPoseFromCentroid_position");
+
+  logger.removeLogEntry(observerName_ + "_debug_contactPose_" + contactName
+                        + "_worldContactPoseFromCentroid_orientation");
+
+  logger.removeLogEntry(observerName_ + "_debug_contactPose_" + contactName + "_inputUserContactKine_position");
+
+  logger.removeLogEntry(observerName_ + "_debug_contactPose_" + contactName + "_inputUserContactKine_orientation");
+  logger.removeLogEntry(observerName_ + "_debug_contactState_isSet_" + contactName);
+  // logger.removeLogEntry(observerName_ + "_debug_zmp_" + contactName);
+}
+
+void MCKineticsObserver::removeContactMeasurementsLogEntries(mc_rtc::Logger & logger, const int & contactIndex)
+{
+  const std::string & contactName = contactsManager_.mapContacts_.getNameFromNum(contactIndex);
+  logger.removeLogEntry(observerName_ + "_measurements_contacts_force_" + contactName + "_measured");
+  logger.removeLogEntry(observerName_ + "_measurements_contacts_force_" + contactName + "_predicted");
+  logger.removeLogEntry(observerName_ + "_measurements_contacts_force_" + contactName + "_corrected");
+
+  logger.removeLogEntry(observerName_ + "_measurements_contacts_torque_" + contactName + "_measured");
+  logger.removeLogEntry(observerName_ + "_measurements_contacts_torque_" + contactName + "_predicted");
+  logger.removeLogEntry(observerName_ + "_measurements_contacts_torque_" + contactName + "_corrected");
+}
+
+} // namespace mc_state_observation
+
+EXPORT_OBSERVER_MODULE("MCKineticsObserver", mc_state_observation::MCKineticsObserver)

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -45,7 +45,7 @@ void MCKineticsObserver::configure(const mc_control::MCController & ctl, const m
 
   std::string contactsDetectionString = static_cast<std::string>(config("contactsDetection"));
   KoContactsManager::ContactsDetection contactsDetectionMethod =
-      contactsManager_.stringToContactsDetection(contactsDetectionString);
+      contactsManager_.stringToContactsDetection(contactsDetectionString, observerName_);
 
   std::vector<std::string> contactsSensorsDisabledInit =
       config("contactsSensorDisabledInit", std::vector<std::string>());

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -1325,7 +1325,7 @@ void MCKineticsObserver::addToLogger(const mc_control::MCController & ctl,
 
   for(auto & contactWithSensor : contactsManager_.contacts())
   {
-    const measurements::ContactWithSensor & contact = contactWithSensor.second;
+    const KoContactWithSensor & contact = contactWithSensor.second;
     logger.addLogEntry(observerName_ + "_debug_wrenchesInCentroid_" + contact.name() + "_force",
                        [contact]() -> Eigen::Vector3d { return contact.wrenchInCentroid_.segment<3>(0); });
     logger.addLogEntry(observerName_ + "_debug_wrenchesInCentroid_" + contact.name() + "_torque",

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -460,7 +460,7 @@ bool MCKineticsObserver::run(const mc_control::MCController & ctl)
 
         for(const int & contactIndex : contactsManager_.contactsFound())
         {
-          KoContactWithSensor contact = contactsManager_.contact(contactIndex);
+          KoContactWithSensor & contact = contactsManager_.contact(contactIndex);
 
           // Update of the force measurements (the contribution of the gravity changed)
           const mc_rbdyn::ForceSensor & forceSensor = robot.forceSensor(contact.forceSensorName());

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -920,75 +920,75 @@ void MCKineticsObserver::updateContact(const mc_control::MCController & ctl,
   // measured wrench in the frame of the contact.
   contact.fbContactKine_ = getContactWorldKinematicsAndWrench(contact, inputRobot, forceSensor, measuredWrench);
 
-  switch(contact.wasAlreadySet_)
+  if(contact.wasAlreadySet_)
   {
     // the contact already exists, it is updated
-    case true:
-      if(contact.sensorEnabled_) // the force sensor attached to the contact is used in the correction by the
-                                 // Kinetics Observer.
-      {
-        observer_.updateContactWithWrenchSensor(contact.contactWrenchVector_, contactSensorCovariance_,
-                                                contact.fbContactKine_, contactIndex);
-      }
-      else { observer_.updateContactWithNoSensor(contact.fbContactKine_, contactIndex); }
 
-      if(withDebugLogs_)
-      {
-        if(contact.sensorEnabled_ && !contact.sensorWasEnabled_)
-        {
-          addContactMeasurementsLogEntries(logger, contactIndex);
-          contact.sensorWasEnabled_ = true;
-        }
-        if(!contact.sensorEnabled_ && contact.sensorWasEnabled_)
-        {
-          removeContactMeasurementsLogEntries(logger, contactIndex);
-          contact.sensorWasEnabled_ = false;
-        }
-      }
-      break;
+    if(contact.sensorEnabled_) // the force sensor attached to the contact is used in the correction by the
+                               // Kinetics Observer.
+    {
+      observer_.updateContactWithWrenchSensor(contact.contactWrenchVector_, contactSensorCovariance_,
+                                              contact.fbContactKine_, contactIndex);
+    }
+    else { observer_.updateContactWithNoSensor(contact.fbContactKine_, contactIndex); }
 
-    // the contact doesn't exist yet, it is updated
-    case false:
-      // reference of the contact in the world / floating base of the input robot
-      so::kine::Kinematics worldContactKineRef;
+    if(withDebugLogs_)
+    {
+      if(contact.sensorEnabled_ && !contact.sensorWasEnabled_)
+      {
+        addContactMeasurementsLogEntries(logger, contactIndex);
+        contact.sensorWasEnabled_ = true;
+      }
+      if(!contact.sensorEnabled_ && contact.sensorWasEnabled_)
+      {
+        removeContactMeasurementsLogEntries(logger, contactIndex);
+        contact.sensorWasEnabled_ = false;
+      }
+    }
+  }
 
-      if(odometryType_ != measurements::OdometryType::None) // the Kinetics Observer performs odometry. The estimated
-                                                            // state is used to provide the new contacts references.
-      {
-        getOdometryWorldContactRest(ctl, contact, worldContactKineRef);
-      }
-      else // we don't perform odometry, the reference pose of the contact is its pose in the control robot
-      {
-        worldContactKineRef = getContactWorldKinematics(contact, robot, forceSensor);
-      }
+  // the contact doesn't exist yet, it is updated
+  else
+  {
+    // reference of the contact in the world / floating base of the input robot
+    so::kine::Kinematics worldContactKineRef;
 
-      if(observer_.getNumberOfSetContacts() > 0) // The initial covariance on the pose of the contact depending on
-                                                 // whether another contact is already set or not
-      {
-        observer_.addContact(worldContactKineRef, contactInitCovarianceNewContacts_, contactProcessCovariance_,
-                             contactIndex, linStiffness_, linDamping_, angStiffness_, angDamping_);
-      }
-      else
-      {
-        observer_.addContact(worldContactKineRef, contactInitCovarianceFirstContacts_, contactProcessCovariance_,
-                             contactIndex, linStiffness_, linDamping_, angStiffness_, angDamping_);
-      }
-      if(contact.sensorEnabled_) // checks if the sensor is used in the correction of the Kinetics Observer
-                                 // or not
-      {
-        // we update the measurements of the sensor and the input kinematics of the contact in the user /
-        // floating base's frame
-        observer_.updateContactWithWrenchSensor(contact.contactWrenchVector_, contactSensorCovariance_,
-                                                contact.fbContactKine_, contactIndex);
-      }
-      else
-      {
-        // we update the input kinematics of the contact in the user / floating base's frame
-        observer_.updateContactWithNoSensor(contact.fbContactKine_, contactIndex);
-      }
+    if(odometryType_ != measurements::OdometryType::None) // the Kinetics Observer performs odometry. The estimated
+                                                          // state is used to provide the new contacts references.
+    {
+      getOdometryWorldContactRest(ctl, contact, worldContactKineRef);
+    }
+    else // we don't perform odometry, the reference pose of the contact is its pose in the control robot
+    {
+      worldContactKineRef = getContactWorldKinematics(contact, robot, forceSensor);
+    }
 
-      if(withDebugLogs_) { addContactLogEntries(logger, contactIndex); }
-      break;
+    if(observer_.getNumberOfSetContacts() > 0) // The initial covariance on the pose of the contact depending on
+                                               // whether another contact is already set or not
+    {
+      observer_.addContact(worldContactKineRef, contactInitCovarianceNewContacts_, contactProcessCovariance_,
+                           contactIndex, linStiffness_, linDamping_, angStiffness_, angDamping_);
+    }
+    else
+    {
+      observer_.addContact(worldContactKineRef, contactInitCovarianceFirstContacts_, contactProcessCovariance_,
+                           contactIndex, linStiffness_, linDamping_, angStiffness_, angDamping_);
+    }
+    if(contact.sensorEnabled_) // checks if the sensor is used in the correction of the Kinetics Observer
+                               // or not
+    {
+      // we update the measurements of the sensor and the input kinematics of the contact in the user /
+      // floating base's frame
+      observer_.updateContactWithWrenchSensor(contact.contactWrenchVector_, contactSensorCovariance_,
+                                              contact.fbContactKine_, contactIndex);
+    }
+    else
+    {
+      // we update the input kinematics of the contact in the user / floating base's frame
+      observer_.updateContactWithNoSensor(contact.fbContactKine_, contactIndex);
+    }
+
+    if(withDebugLogs_) { addContactLogEntries(logger, contactIndex); }
   }
 }
 

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -80,7 +80,7 @@ void MCKineticsObserver::configure(const mc_control::MCController & ctl, const m
     std::vector<std::string> surfacesForContactDetection =
         config("surfacesForContactDetection", std::vector<std::string>());
 
-    KoContactsManager::ContactsManagerSurfacesConfiguration contactsConfig(observerName_, surfacesForContactDetection);
+    measurements::ContactsManagerSurfacesConfiguration contactsConfig(observerName_, surfacesForContactDetection);
 
     contactsConfig.contactDetectionThreshold(contactDetectionThreshold_)
         .contactSensorsDisabledInit(contactsSensorsDisabledInit)
@@ -89,7 +89,7 @@ void MCKineticsObserver::configure(const mc_control::MCController & ctl, const m
   }
   if(contactsDetectionMethod == KoContactsManager::ContactsDetection::Sensors)
   {
-    KoContactsManager::ContactsManagerSensorsConfiguration contactsConfig(observerName_);
+    measurements::ContactsManagerSensorsConfiguration contactsConfig(observerName_);
     contactsConfig.contactDetectionThreshold(contactDetectionThreshold_)
         .contactSensorsDisabledInit(contactsSensorsDisabledInit)
         .verbose(true)
@@ -98,7 +98,7 @@ void MCKineticsObserver::configure(const mc_control::MCController & ctl, const m
   }
   if(contactsDetectionMethod == KoContactsManager::ContactsDetection::Solver)
   {
-    KoContactsManager::ContactsManagerSolverConfiguration contactsConfig(observerName_);
+    measurements::ContactsManagerSolverConfiguration contactsConfig(observerName_);
     contactsConfig.contactDetectionThreshold(contactDetectionThreshold_).verbose(true);
     contactsManager_.init(ctl, robot_, contactsConfig);
   }

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -555,7 +555,7 @@ bool MCKineticsObserver::run(const mc_control::MCController & ctl)
 
       for(const int & contactIndex : contactsManager_.contactsFound())
       {
-        KoContactWithSensor contact = contactsManager_.contact(contactIndex);
+        KoContactWithSensor & contact = contactsManager_.contact(contactIndex);
 
         // Update of the force measurements (the offset due to the gravity changed)
         const mc_rbdyn::ForceSensor & forceSensor = inputRobot.forceSensor(contact.forceSensorName());

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -4,7 +4,6 @@
 #include <mc_observers/ObserverMacros.h>
 #include <mc_rtc/io_utils.h>
 #include <mc_rtc/logging.h>
-#include "mc_state_observation/measurements/measurementsTools.h"
 #include <mc_state_observation/MCKineticsObserver.h>
 #include <mc_state_observation/gui_helpers.h>
 

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -1,18 +1,7 @@
 /* Copyright 2017-2020 CNRS-AIST JRL, CNRS-UM LIRMM */
-
-#include <mc_control/MCController.h>
 #include <mc_observers/ObserverMacros.h>
-#include <mc_rtc/io_utils.h>
-#include <mc_rtc/logging.h>
 #include <mc_state_observation/MCKineticsObserver.h>
 #include <mc_state_observation/gui_helpers.h>
-
-#include <RBDyn/CoM.h>
-#include <RBDyn/FA.h>
-#include <RBDyn/FK.h>
-#include <RBDyn/FV.h>
-
-#include <typeinfo>
 
 #include <mc_state_observation/conversions/kinematics.h>
 

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -43,13 +43,12 @@ void MCKineticsObserver::configure(const mc_control::MCController & ctl, const m
 
   std::string typeOfOdometry = static_cast<std::string>(config("odometryType"));
 
-  if(typeOfOdometry == "flatOdometry") { odometryType_ = measurements::OdometryType::Flat; }
-  else if(typeOfOdometry == "6dOdometry") { odometryType_ = measurements::OdometryType::Odometry6d; }
+  if(typeOfOdometry == "Flat") { odometryType_ = measurements::OdometryType::Flat; }
+  else if(typeOfOdometry == "6D") { odometryType_ = measurements::OdometryType::Odometry6d; }
   else if(typeOfOdometry == "None") { odometryType_ = measurements::OdometryType::None; }
   else
   {
-    mc_rtc::log::error_and_throw<std::runtime_error>(
-        "Odometry type not allowed. Please pick among : [None, flatOdometry, 6dOdometry]");
+    mc_rtc::log::error_and_throw<std::runtime_error>("Odometry type not allowed. Please pick among : [None, Flat, 6D]");
   }
 
   config("withDebugLogs", withDebugLogs_);
@@ -66,9 +65,9 @@ void MCKineticsObserver::configure(const mc_control::MCController & ctl, const m
   std::string contactsDetection = static_cast<std::string>(config("contactsDetection"));
 
   KoContactsManager::ContactsDetection contactsDetectionMethod = KoContactsManager::ContactsDetection::Undefined;
-  if(contactsDetection == "fromThreshold") { contactsDetectionMethod = KoContactsManager::ContactsDetection::Sensors; }
+  if(contactsDetection == "Sensors") { contactsDetectionMethod = KoContactsManager::ContactsDetection::Sensors; }
   else if(contactsDetection == "Surfaces") { contactsDetectionMethod = KoContactsManager::ContactsDetection::Surfaces; }
-  else if(contactsDetection == "fromSolver") { contactsDetectionMethod = KoContactsManager::ContactsDetection::Solver; }
+  else if(contactsDetection == "Solver") { contactsDetectionMethod = KoContactsManager::ContactsDetection::Solver; }
 
   std::vector<std::string> contactsSensorsDisabledInit =
       config("contactsSensorDisabledInit", std::vector<std::string>());
@@ -1040,10 +1039,10 @@ void MCKineticsObserver::addToLogger(const mc_control::MCController & ctl,
                        switch(odometryType_)
                        {
                          case measurements::OdometryType::Flat:
-                           return "flatOdometry";
+                           return "Flat";
                            break;
                          case measurements::OdometryType::Odometry6d:
-                           return "6dOdometry";
+                           return "6D";
                            break;
                          case measurements::OdometryType::None:
                            return "None";
@@ -1422,8 +1421,8 @@ void MCKineticsObserver::removeFromLogger(mc_rtc::Logger & logger, const std::st
 void MCKineticsObserver::changeOdometryType(const mc_control::MCController & ctl, const std::string & newOdometryType)
 {
   OdometryType prevOdometryType = odometryType_;
-  if(newOdometryType == "flatOdometry") { odometryType_ = measurements::OdometryType::Flat; }
-  else if(newOdometryType == "6dOdometry") { odometryType_ = measurements::OdometryType::Odometry6d; }
+  if(newOdometryType == "Flat") { odometryType_ = measurements::OdometryType::Flat; }
+  else if(newOdometryType == "6D") { odometryType_ = measurements::OdometryType::Odometry6d; }
 
   // if the type didn't change, we stop the function here
   if(odometryType_ == prevOdometryType) { return; }
@@ -1451,15 +1450,15 @@ void MCKineticsObserver::addToGUI(const mc_control::MCController & ctl,
   if(odometryType_ != measurements::OdometryType::None)
   {
     gui.addElement({observerName_, "Odometry"}, mc_rtc::gui::ComboInput(
-                                                                  "Choose from list", {"6dOdometry", "flatOdometry"},
+                                                                  "Choose from list", {"6D", "Flat"},
                                                                   [this]() -> std::string {
                                                                     if(odometryType_ == measurements::OdometryType::Flat)
                                                                     {
-                                                                      return "flatOdometry";
+                                                                      return "Flat";
                                                                     }
                                                                     else
                                                                     {
-                                                                      return "6dOdometry";
+                                                                      return "6D";
                                                                     }
                                                                   },
                                                                   [this, &ctl](const std::string & typeOfOdometry) {

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -353,7 +353,16 @@ bool MCKineticsObserver::run(const mc_control::MCController & ctl)
 
   // Copy the real configuration except for the floating base
   const auto & realQ = realRobot.mbc().q;
+  const auto & realAlpha = realRobot.mbc().alpha;
+  const auto & realAlphaD = realRobot.mbc().alphaD;
+
   std::copy(std::next(realQ.begin()), realQ.end(), std::next(inputRobot.mbc().q.begin()));
+  std::copy(std::next(realAlpha.begin()), realAlpha.end(), std::next(inputRobot.mbc().alpha.begin()));
+  std::copy(std::next(realAlphaD.begin()), realAlphaD.end(), std::next(inputRobot.mbc().alphaD.begin()));
+
+  inputRobot.forwardKinematics();
+  inputRobot.forwardVelocity();
+  inputRobot.forwardAcceleration();
 
   // The input robot copies the real robot to update the encoder values.
   // Then its floating base is brung back to the origin of the world frame and given zero velocities and accelerations

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -679,7 +679,7 @@ void MCKineticsObserver::updateIMUs(const mc_rbdyn::Robot & measRobot, const mc_
     so::kine::Kinematics bodyImuKine = conversions::kinematics::fromSva(
         bodyImuPose, so::kine::Kinematics::Flags::vel | so::kine::Kinematics::Flags::acc);
 
-    so::kine::Kinematics worldBodyKine = conversions::kinematics::kinematicsFromSva(
+    so::kine::Kinematics worldBodyKine = conversions::kinematics::fromSva(
         inputRobot.mbc().bodyPosW[inputRobot.bodyIndexByName(imu.parentBody())],
         inputRobot.mbc().bodyVelW[inputRobot.bodyIndexByName(imu.parentBody())],
         inputRobot.mbc().bodyAccB[inputRobot.bodyIndexByName(imu.parentBody())], true, false);

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -29,15 +29,9 @@ void MCKineticsObserver::configure(const mc_control::MCController & ctl, const m
   config("debug", debug_);
   config("verbose", verbose_);
 
+  // we set the desired type of odometry
   std::string typeOfOdometry = static_cast<std::string>(config("odometryType"));
-
-  if(typeOfOdometry == "Flat") { odometryType_ = measurements::OdometryType::Flat; }
-  else if(typeOfOdometry == "6D") { odometryType_ = measurements::OdometryType::Odometry6d; }
-  else if(typeOfOdometry == "None") { odometryType_ = measurements::OdometryType::None; }
-  else
-  {
-    mc_rtc::log::error_and_throw<std::runtime_error>("Odometry type not allowed. Please pick among : [None, Flat, 6D]");
-  }
+  measurements::stringToOdometryType(typeOfOdometry, odometryType_);
 
   config("withDebugLogs", withDebugLogs_);
 
@@ -46,19 +40,9 @@ void MCKineticsObserver::configure(const mc_control::MCController & ctl, const m
   double contactDetectionPropThreshold = config("contactDetectionPropThreshold", 0.11);
   contactDetectionThreshold_ = robot.mass() * so::cst::gravityConstant * contactDetectionPropThreshold;
 
-  std::string contactsDetection = static_cast<std::string>(config("contactsDetection"));
-
-  KoContactsManager::ContactsDetection contactsDetectionMethod = KoContactsManager::ContactsDetection::Undefined;
-  if(contactsDetection == "Sensors") { contactsDetectionMethod = KoContactsManager::ContactsDetection::Sensors; }
-  else if(contactsDetection == "Surfaces") { contactsDetectionMethod = KoContactsManager::ContactsDetection::Surfaces; }
-  else if(contactsDetection == "Solver") { contactsDetectionMethod = KoContactsManager::ContactsDetection::Solver; }
-
-  if(contactsDetectionMethod == KoContactsManager::ContactsDetection::Undefined)
-  {
-    mc_rtc::log::error_and_throw<std::runtime_error>(
-        "Contacts detection type not allowed. Please pick among : [Solver, Sensors, Surfaces] or "
-        "initialize a list of surfaces with the variable surfacesForContactDetection");
-  }
+  std::string contactsDetectionString = static_cast<std::string>(config("contactsDetection"));
+  KoContactsManager::ContactsDetection contactsDetectionMethod =
+      contactsManager_.stringToContactsDetection(contactsDetectionString);
 
   std::vector<std::string> contactsSensorsDisabledInit =
       config("contactsSensorDisabledInit", std::vector<std::string>());

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -12,7 +12,7 @@ namespace so = stateObservation;
 namespace mc_state_observation
 {
 MCKineticsObserver::MCKineticsObserver(const std::string & type, double dt)
-: mc_observers::Observer(type, dt), observer_(4, 2), tiltObserver_(type, dt, true, "KoBackup_")
+: mc_observers::Observer(type, dt), observer_(4, 2), tiltObserver_(type, dt, true, "KoBackup_TiltObserver")
 {
   observer_.setSamplingTime(dt);
 }

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -315,8 +315,9 @@ bool MCKineticsObserver::run(const mc_control::MCController & ctl)
   auto & inputRobot = my_robots_->robot("inputRobot");
   auto & logger = (const_cast<mc_control::MCController &>(ctl)).logger();
 
-  inputRobot.mbc() = realRobot.mbc();
-  inputRobot.mb() = realRobot.mb();
+  // Copy the real configuration except for the floating base
+  const auto & realQ = realRobot.mbc().q;
+  std::copy(std::next(realQ.begin()), realQ.end(), std::next(inputRobot.mbc().q.begin()));
 
   // The input robot copies the real robot to update the encoder values.
   // Then its floating base is brung back to the origin of the world frame and given zero velocities and accelerations

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -1070,7 +1070,7 @@ void MCKineticsObserver::addToLogger(const mc_control::MCController & ctl,
                      });
 
   /* Plots of the updated state */
-  conversions::kinematics::addToLogger(globalCentroidKinematics_, logger, observerName_ + "_globalWorldCentroidState");
+  conversions::kinematics::addToLogger(logger, globalCentroidKinematics_, observerName_ + "_globalWorldCentroidState");
   logger.addLogEntry(observerName_ + "_globalWorldCentroidState_positionW_",
                      [this]() -> Eigen::Vector3d { return globalCentroidKinematics_.position(); });
   logger.addLogEntry(observerName_ + "_globalWorldCentroidState_linVelW",

--- a/src/MCKineticsObserver.cpp
+++ b/src/MCKineticsObserver.cpp
@@ -1622,10 +1622,10 @@ void MCKineticsObserver::addContactLogEntries(const mc_control::MCController & c
         [this, &contact]() -> Eigen::Quaternion<double>
         { return observer_.getCentroidContactInputPose(contact.id()).orientation.inverse().toQuaternion(); });
 
-    logger.addLogEntry(observerName_ + "_debug_contactPose_" + contact.name()
-                           + "_worldContactPoseFromCentroid_position",
-                       [this, &contact]() -> Eigen::Vector3d
-                       { return observer_.getWorldContactPoseFromCentroid(contact.id()).position(); });
+    logger.addLogEntry(
+        observerName_ + "_debug_contactPose_" + contact.name() + "_worldContactPoseFromCentroid_position", &contact,
+        [this, &contact]() -> Eigen::Vector3d
+        { return observer_.getWorldContactPoseFromCentroid(contact.id()).position(); });
 
     logger.addLogEntry(
         observerName_ + "_debug_contactPose_" + contact.name() + "_worldContactPoseFromCentroid_orientation", &contact,

--- a/src/NaiveOdometry.cpp
+++ b/src/NaiveOdometry.cpp
@@ -1,0 +1,231 @@
+/* Copyright 2017-2020 CNRS-AIST JRL, CNRS-UM LIRMM */
+
+#include <mc_control/MCController.h>
+#include <mc_observers/ObserverMacros.h>
+#include <mc_rtc/io_utils.h>
+#include <mc_rtc/logging.h>
+#include "mc_state_observation/observersTools/leggedOdometryTools.h"
+#include <mc_state_observation/NaiveOdometry.h>
+#include <mc_state_observation/gui_helpers.h>
+
+#include <RBDyn/CoM.h>
+#include <RBDyn/FA.h>
+#include <RBDyn/FK.h>
+#include <RBDyn/FV.h>
+
+#include <iostream>
+
+namespace mc_state_observation
+{
+NaiveOdometry::NaiveOdometry(const std::string & type, double dt) : mc_observers::Observer(type, dt) {}
+
+///////////////////////////////////////////////////////////////////////
+/// --------------------------Core functions---------------------------
+///////////////////////////////////////////////////////////////////////
+
+void NaiveOdometry::configure(const mc_control::MCController & ctl, const mc_rtc::Configuration & config)
+{
+  robot_ = config("robot", ctl.robot().name());
+  std::string typeOfOdometry = static_cast<std::string>(config("odometryType"));
+  measurements::OdometryType odometryType;
+
+  bool verbose = config("verbose", true);
+
+  if(typeOfOdometry == "flatOdometry") { odometryType = measurements::flatOdometry; }
+  else if(typeOfOdometry == "6dOdometry") { odometryType = measurements::odometry6d; }
+  else
+  {
+    mc_rtc::log::error_and_throw<std::runtime_error>(
+        "Odometry type not allowed. Please pick among : [flatOdometry, 6dOdometry]");
+  }
+
+  bool velUpdatedUpstream = config("velUpdatedUpstream");
+  accUpdatedUpstream_ = config("accUpdatedUpstream");
+
+  odometryManager_.init(ctl, robot_, "NaiveOdometry", odometryType, true, velUpdatedUpstream, accUpdatedUpstream_,
+                        verbose, true);
+
+  /* Configuration of the contacts detection */
+
+  // surfaces used for the contact detection. If the desired detection method doesn't use surfaces, we make sure this
+  // list is not filled in the configuration file to avoid the use of an undesired method.
+  std::vector<std::string> surfacesForContactDetection;
+  config("surfacesForContactDetection", surfacesForContactDetection);
+
+  std::string contactsDetection = static_cast<std::string>(config("contactsDetection"));
+
+  LoContactsManager::ContactsDetection contactsDetectionMethod = LoContactsManager::ContactsDetection::undefined;
+  if(contactsDetection == "fromThreshold")
+  {
+    contactsDetectionMethod = LoContactsManager::ContactsDetection::fromThreshold;
+  }
+  else if(contactsDetection == "fromSurfaces")
+  {
+    contactsDetectionMethod = LoContactsManager::ContactsDetection::fromSurfaces;
+  }
+  else if(contactsDetection == "fromSolver")
+  {
+    contactsDetectionMethod = LoContactsManager::ContactsDetection::fromSolver;
+  }
+
+  if(contactsDetectionMethod == LoContactsManager::ContactsDetection::undefined)
+  {
+    mc_rtc::log::error_and_throw<std::runtime_error>(
+        "Contacts detection type not allowed. Please pick among : [fromSolver, fromThreshold, fromSurfaces] or "
+        "initialize a list of surfaces with the variable surfacesForContactDetection");
+  }
+  if(surfacesForContactDetection.size() > 0)
+  {
+    if(contactsDetectionMethod != LoContactsManager::ContactsDetection::fromSurfaces)
+    {
+      mc_rtc::log::error_and_throw<std::runtime_error>(
+          "Another type of contacts detection is currently used, please change it to 'fromSurfaces' or empty the "
+          "surfacesForContactDetection variable");
+    }
+  }
+  else if(contactsDetectionMethod != LoContactsManager::ContactsDetection::fromSurfaces)
+  {
+    mc_rtc::log::error_and_throw<std::runtime_error>(
+        "You selected the contacts detection using surfaces but didn't add the list of surfaces, please add it usign "
+        "the variable surfacesForContactDetection");
+  }
+
+  double contactDetectionPropThreshold = config("contactDetectionPropThreshold", 0.11);
+  contactDetectionThreshold_ = mass_ * so::cst::gravityConstant * contactDetectionPropThreshold;
+  std::vector<std::string> contactsSensorDisabledInit =
+      config("contactsSensorDisabledInit", std::vector<std::string>());
+
+  if(contactsDetectionMethod == LoContactsManager::ContactsDetection::fromSurfaces)
+  {
+    odometryManager_.initDetection(ctl, robot_, contactsDetectionMethod, surfacesForContactDetection,
+                                   contactsSensorDisabledInit, contactDetectionThreshold_);
+  }
+  else
+  {
+    std::vector<std::string> forceSensorsToOmit = config("forceSensorsToOmit", std::vector<std::string>());
+    odometryManager_.initDetection(ctl, robot_, contactsDetectionMethod, contactsSensorDisabledInit,
+                                   contactDetectionThreshold_, forceSensorsToOmit);
+  }
+}
+
+void NaiveOdometry::reset(const mc_control::MCController & ctl)
+{
+  const auto & robot = ctl.robot(robot_);
+  const auto & realRobot = ctl.realRobot(robot_);
+  const auto & realRobotModule = realRobot.module();
+
+  rbd::MultiBodyGraph mergeMbg(realRobotModule.mbg);
+  std::map<std::string, std::vector<double>> jointPosByName;
+  for(int i = 0; i < realRobotModule.mb.nrJoints(); ++i)
+  {
+    auto jointName = realRobotModule.mb.joint(i).name();
+    auto jointIndex = static_cast<unsigned long>(realRobotModule.mb.jointIndexByName(jointName));
+    jointPosByName[jointName] = realRobotModule.mbc.q[jointIndex];
+  }
+
+  std::vector<std::string> rootJoints = {};
+  int nbJoints = static_cast<int>(realRobot.mb().joints().size());
+  for(int i = 0; i < nbJoints; ++i)
+  {
+    if(realRobot.mb().predecessor(i) == 0) { rootJoints.push_back(realRobot.mb().joint(i).name()); }
+  }
+  for(const auto & joint : rootJoints)
+  {
+    if(!realRobot.hasJoint(joint))
+    {
+      mc_rtc::log::error_and_throw<std::runtime_error>("Robot does not have a joint named {}", joint);
+    }
+    mergeMbg.mergeSubBodies(realRobotModule.mb.body(0).name(), joint, jointPosByName);
+  }
+
+  mass(ctl.realRobot(robot_).mass());
+
+  my_robots_ = mc_rbdyn::Robots::make();
+  my_robots_->robotCopy(robot, robot.name());
+  ctl.gui()->addElement(
+      {"Robots"},
+      mc_rtc::gui::Robot("NaiveOdometry", [this]() -> const mc_rbdyn::Robot & { return my_robots_->robot(); }));
+
+  X_0_fb_.translation() = realRobot.posW().translation();
+  X_0_fb_.rotation() = realRobot.posW().rotation();
+}
+
+bool NaiveOdometry::run(const mc_control::MCController & ctl)
+{
+  auto & logger = (const_cast<mc_control::MCController &>(ctl)).logger();
+
+  //  if the acceleration was estimated by a previous estimator, it can be updated
+  if(accUpdatedUpstream_) { odometryManager_.run(ctl, logger, X_0_fb_, v_fb_0_, a_fb_0_); }
+  else { odometryManager_.run(ctl, logger, X_0_fb_, v_fb_0_); }
+
+  /* Update of the visual representation (only a visual feature) of the observed robot */
+  my_robots_->robot().mbc().q = ctl.realRobot().mbc().q;
+  update(my_robots_->robot());
+
+  return true;
+}
+
+///////////////////////////////////////////////////////////////////////
+/// -------------------------Called functions--------------------------
+///////////////////////////////////////////////////////////////////////
+
+void NaiveOdometry::update(mc_control::MCController & ctl) // this function is called by the pipeline if the
+                                                           // update is set to true in the configuration file
+{
+  auto & realRobot = ctl.realRobot(robot_);
+  update(realRobot);
+}
+
+void NaiveOdometry::update(mc_rbdyn::Robot & robot)
+{
+  robot.posW(X_0_fb_);
+  robot.velW(v_fb_0_.vector());
+  robot.accW(a_fb_0_.vector());
+}
+
+void NaiveOdometry::mass(double mass)
+{
+  mass_ = mass;
+}
+
+///////////////////////////////////////////////////////////////////////
+/// -------------------------------Logs--------------------------------
+///////////////////////////////////////////////////////////////////////
+
+void NaiveOdometry::addToLogger(const mc_control::MCController &, mc_rtc::Logger & logger, const std::string & category)
+{
+  logger.addLogEntry(category + "_naive_fb_posW", [this]() -> const sva::PTransformd & { return X_0_fb_; });
+  logger.addLogEntry(category + "_naive_fb_velW", [this]() -> const sva::MotionVecd & { return v_fb_0_; });
+  logger.addLogEntry(category + "_naive_fb_accW", [this]() -> const sva::MotionVecd & { return a_fb_0_; });
+
+  logger.addLogEntry(category + "_naive_fb_yaw",
+                     [this]() -> double { return -so::kine::rotationMatrixToYawAxisAgnostic(X_0_fb_.rotation()); });
+
+  logger.addLogEntry(category + "_constants_forceThreshold", [this]() -> double { return contactDetectionThreshold_; });
+}
+
+void NaiveOdometry::removeFromLogger(mc_rtc::Logger & logger, const std::string & category)
+{
+  logger.removeLogEntry(category + "_posW");
+  logger.removeLogEntry(category + "_velW");
+  logger.removeLogEntry(category + "_mass");
+  logger.removeLogEntry(category + "_flexStiffness");
+  logger.removeLogEntry(category + "_flexDamping");
+}
+
+void NaiveOdometry::addToGUI(const mc_control::MCController &,
+                             mc_rtc::gui::StateBuilder & gui,
+                             const std::vector<std::string> & category)
+{
+  using namespace mc_rtc::gui;
+  // unused variables
+  (void)gui;
+  (void)category;
+  // clang-format off
+
+  // clang-format on
+}
+
+} // namespace mc_state_observation
+
+EXPORT_OBSERVER_MODULE("NaiveOdometry", mc_state_observation::NaiveOdometry)

--- a/src/NaiveOdometry.cpp
+++ b/src/NaiveOdometry.cpp
@@ -1,16 +1,8 @@
 /* Copyright 2017-2020 CNRS-AIST JRL, CNRS-UM LIRMM */
 
-#include <mc_control/MCController.h>
 #include <mc_observers/ObserverMacros.h>
-#include <mc_rtc/io_utils.h>
-#include <mc_rtc/logging.h>
 #include <mc_state_observation/NaiveOdometry.h>
 #include <mc_state_observation/gui_helpers.h>
-
-#include <RBDyn/CoM.h>
-#include <RBDyn/FA.h>
-#include <RBDyn/FK.h>
-#include <RBDyn/FV.h>
 
 #include <iostream>
 

--- a/src/NaiveOdometry.cpp
+++ b/src/NaiveOdometry.cpp
@@ -4,7 +4,6 @@
 #include <mc_observers/ObserverMacros.h>
 #include <mc_rtc/io_utils.h>
 #include <mc_rtc/logging.h>
-#include "mc_state_observation/odometry/leggedOdometry.h"
 #include <mc_state_observation/NaiveOdometry.h>
 #include <mc_state_observation/gui_helpers.h>
 

--- a/src/NaiveOdometry.cpp
+++ b/src/NaiveOdometry.cpp
@@ -1,8 +1,16 @@
 /* Copyright 2017-2020 CNRS-AIST JRL, CNRS-UM LIRMM */
 
+#include <mc_control/MCController.h>
 #include <mc_observers/ObserverMacros.h>
+#include <mc_rtc/io_utils.h>
+#include <mc_rtc/logging.h>
 #include <mc_state_observation/NaiveOdometry.h>
 #include <mc_state_observation/gui_helpers.h>
+
+#include <RBDyn/CoM.h>
+#include <RBDyn/FA.h>
+#include <RBDyn/FK.h>
+#include <RBDyn/FV.h>
 
 #include <iostream>
 

--- a/src/NaiveOdometry.cpp
+++ b/src/NaiveOdometry.cpp
@@ -10,7 +10,10 @@
 namespace so = stateObservation;
 namespace mc_state_observation
 {
-NaiveOdometry::NaiveOdometry(const std::string & type, double dt) : mc_observers::Observer(type, dt) {}
+NaiveOdometry::NaiveOdometry(const std::string & type, double dt)
+: mc_observers::Observer(type, dt), odometryManager_(category_)
+{
+}
 
 ///////////////////////////////////////////////////////////////////////
 /// --------------------------Core functions---------------------------

--- a/src/NaiveOdometry.cpp
+++ b/src/NaiveOdometry.cpp
@@ -54,24 +54,16 @@ void NaiveOdometry::configure(const mc_control::MCController & ctl, const mc_rtc
 
   if(contactsDetectionMethod == LoContactsManager::ContactsDetection::Surfaces)
   {
-    std::vector<std::string> contactSensorsDisabledInit =
-        config("contactsSensorDisabledInit", std::vector<std::string>());
-
     measurements::ContactsManagerSurfacesConfiguration contactsConfig(category_, surfacesForContactDetection);
-    contactsConfig.contactDetectionThreshold(contactDetectionThreshold_)
-        .contactSensorsDisabledInit(contactSensorsDisabledInit)
-        .verbose(verbose);
+    contactsConfig.contactDetectionThreshold(contactDetectionThreshold_).verbose(verbose);
     odometryManager_.init(ctl, odomConfig, contactsConfig);
   }
   if(contactsDetectionMethod == LoContactsManager::ContactsDetection::Sensors)
   {
     std::vector<std::string> forceSensorsToOmit = config("forceSensorsToOmit", std::vector<std::string>());
-    std::vector<std::string> contactSensorsDisabledInit =
-        config("contactsSensorDisabledInit", std::vector<std::string>());
 
     measurements::ContactsManagerSensorsConfiguration contactsConfig(category_);
     contactsConfig.contactDetectionThreshold(contactDetectionThreshold_)
-        .contactSensorsDisabledInit(contactSensorsDisabledInit)
         .verbose(verbose)
         .forceSensorsToOmit(forceSensorsToOmit);
     odometryManager_.init(ctl, odomConfig, contactsConfig);

--- a/src/NaiveOdometry.cpp
+++ b/src/NaiveOdometry.cpp
@@ -47,7 +47,9 @@ void NaiveOdometry::configure(const mc_control::MCController & ctl, const mc_rtc
     mc_rtc::log::error_and_throw("The allows values of velocityUpdate are [noUpdate, fromUpstream, finiteDiff]");
   }
 
-  odometryManager_.init(ctl, robot_, "NaiveOdometry", odometryType, true, velUpdate_, verbose, true);
+  odometry::LeggedOdometryManager::Configuration odomConfig(robot_, category_, odometryType);
+  odomConfig.velocityUpdate(velUpdate_).withModeSwitchInGui(true).withYawEstimation(true);
+  odometryManager_.init(ctl, odomConfig, verbose);
 
   /* Configuration of the contacts detection */
 
@@ -138,8 +140,7 @@ void NaiveOdometry::reset(const mc_control::MCController & ctl)
   my_robots_ = mc_rbdyn::Robots::make();
   my_robots_->robotCopy(robot, robot.name());
   ctl.gui()->addElement(
-      {"Robots"},
-      mc_rtc::gui::Robot("NaiveOdometry", [this]() -> const mc_rbdyn::Robot & { return my_robots_->robot(); }));
+      {"Robots"}, mc_rtc::gui::Robot(category_, [this]() -> const mc_rbdyn::Robot & { return my_robots_->robot(); }));
 
   X_0_fb_.translation() = realRobot.posW().translation();
   X_0_fb_.rotation() = realRobot.posW().rotation();

--- a/src/NaiveOdometry.cpp
+++ b/src/NaiveOdometry.cpp
@@ -1,6 +1,7 @@
 /* Copyright 2017-2020 CNRS-AIST JRL, CNRS-UM LIRMM */
 
 #include <mc_observers/ObserverMacros.h>
+#include "mc_state_observation/odometry/LeggedOdometryManager.h"
 #include <mc_state_observation/NaiveOdometry.h>
 #include <mc_state_observation/gui_helpers.h>
 
@@ -23,7 +24,7 @@ void NaiveOdometry::configure(const mc_control::MCController & ctl, const mc_rtc
 
   /* Configuration of the odometry */
   std::string odometryTypeStr = static_cast<std::string>(config("odometryType"));
-  std::string velocityUpdate = "noUpdate";
+  std::string velocityUpdate = "NoUpdate";
   config("velocityUpdate", velocityUpdate);
 
   odometry::LeggedOdometryManager::Configuration odomConfig(robot_, category_, odometryTypeStr);
@@ -38,7 +39,7 @@ void NaiveOdometry::configure(const mc_control::MCController & ctl, const mc_rtc
 
   std::string contactsDetectionString = static_cast<std::string>(config("contactsDetection"));
   LoContactsManager::ContactsDetection contactsDetectionMethod =
-      odometryManager_.contactsManager().stringToContactsDetection(contactsDetectionString);
+      odometryManager_.contactsManager().stringToContactsDetection(contactsDetectionString, category_);
 
   if(surfacesForContactDetection.size() > 0
      && contactsDetectionMethod != LoContactsManager::ContactsDetection::Surfaces)
@@ -130,7 +131,7 @@ bool NaiveOdometry::run(const mc_control::MCController & ctl)
 
   // The odometry manager will update the velocity with the desired method (update of the estimated made upstream or
   // with finite differences)
-  if(odometryManager_.velocityUpdate_ != odometry::LeggedOdometryManager::noUpdate)
+  if(odometryManager_.velocityUpdate_ != odometry::LeggedOdometryManager::VelocityUpdate::NoUpdate)
   {
     odometryManager_.run(ctl, logger, X_0_fb_, v_0_fb);
   }

--- a/src/NaiveOdometry.cpp
+++ b/src/NaiveOdometry.cpp
@@ -32,12 +32,11 @@ void NaiveOdometry::configure(const mc_control::MCController & ctl, const mc_rtc
 
   bool verbose = config("verbose", true);
 
-  if(typeOfOdometry == "flatOdometry") { odometryType = measurements::OdometryType::Flat; }
-  else if(typeOfOdometry == "6dOdometry") { odometryType = measurements::OdometryType::Odometry6d; }
+  if(typeOfOdometry == "Flat") { odometryType = measurements::OdometryType::Flat; }
+  else if(typeOfOdometry == "6D") { odometryType = measurements::OdometryType::Odometry6d; }
   else
   {
-    mc_rtc::log::error_and_throw<std::runtime_error>(
-        "Odometry type not allowed. Please pick among : [flatOdometry, 6dOdometry]");
+    mc_rtc::log::error_and_throw<std::runtime_error>("Odometry type not allowed. Please pick among : [Flat, 6D]");
   }
 
   bool velUpdatedUpstream = config("velUpdatedUpstream");
@@ -58,12 +57,12 @@ void NaiveOdometry::configure(const mc_control::MCController & ctl, const mc_rtc
   LoContactsManager::ContactsDetection contactsDetectionMethod = LoContactsManager::ContactsDetection::Undefined;
   if(contactsDetection == "Sensors") { contactsDetectionMethod = LoContactsManager::ContactsDetection::Sensors; }
   else if(contactsDetection == "Surfaces") { contactsDetectionMethod = LoContactsManager::ContactsDetection::Surfaces; }
-  else if(contactsDetection == "fromSolver") { contactsDetectionMethod = LoContactsManager::ContactsDetection::Solver; }
+  else if(contactsDetection == "Solver") { contactsDetectionMethod = LoContactsManager::ContactsDetection::Solver; }
 
   if(contactsDetectionMethod == LoContactsManager::ContactsDetection::Undefined)
   {
     mc_rtc::log::error_and_throw<std::runtime_error>(
-        "Contacts detection type not allowed. Please pick among : [fromSolver, Sensors, Surfaces] or "
+        "Contacts detection type not allowed. Please pick among : [Solver, Sensors, Surfaces] or "
         "initialize a list of surfaces with the variable surfacesForContactDetection");
   }
   if(surfacesForContactDetection.size() > 0)

--- a/src/NaiveOdometry.cpp
+++ b/src/NaiveOdometry.cpp
@@ -47,9 +47,6 @@ void NaiveOdometry::configure(const mc_control::MCController & ctl, const mc_rtc
     mc_rtc::log::error_and_throw("The allows values of velocityUpdate are [noUpdate, fromUpstream, finiteDiff]");
   }
 
-  odometry::LeggedOdometryManager::Configuration odomConfig(robot_, category_, odometryType);
-  odomConfig.velocityUpdate(velUpdate_).withModeSwitchInGui(true).withYawEstimation(true);
-
   /* Configuration of the contacts detection */
 
   // surfaces used for the contact detection. If the desired detection method doesn't use surfaces, we make sure this
@@ -80,13 +77,15 @@ void NaiveOdometry::configure(const mc_control::MCController & ctl, const mc_rtc
 
   double contactDetectionPropThreshold = config("contactDetectionPropThreshold", 0.11);
   contactDetectionThreshold_ = mass_ * so::cst::gravityConstant * contactDetectionPropThreshold;
-  std::vector<std::string> contactSensorsDisabledInit =
-      config("contactsSensorDisabledInit", std::vector<std::string>());
 
+  odometry::LeggedOdometryManager::Configuration odomConfig(robot_, category_, odometryType);
+  odomConfig.velocityUpdate(velUpdate_).withModeSwitchInGui(true).withYawEstimation(true);
   if(contactsDetectionMethod == LoContactsManager::ContactsDetection::Surfaces)
   {
-    odometry::LeggedOdometryManager::ContactsManager::ContactsManagerSurfacesConfiguration contactsConfig(
-        category_, surfacesForContactDetection);
+    std::vector<std::string> contactSensorsDisabledInit =
+        config("contactsSensorDisabledInit", std::vector<std::string>());
+
+    measurements::ContactsManagerSurfacesConfiguration contactsConfig(category_, surfacesForContactDetection);
     contactsConfig.contactDetectionThreshold(contactDetectionThreshold_)
         .contactSensorsDisabledInit(contactSensorsDisabledInit)
         .verbose(verbose);
@@ -95,8 +94,10 @@ void NaiveOdometry::configure(const mc_control::MCController & ctl, const mc_rtc
   if(contactsDetectionMethod == LoContactsManager::ContactsDetection::Sensors)
   {
     std::vector<std::string> forceSensorsToOmit = config("forceSensorsToOmit", std::vector<std::string>());
+    std::vector<std::string> contactSensorsDisabledInit =
+        config("contactsSensorDisabledInit", std::vector<std::string>());
 
-    odometry::LeggedOdometryManager::ContactsManager::ContactsManagerSensorsConfiguration contactsConfig(category_);
+    measurements::ContactsManagerSensorsConfiguration contactsConfig(category_);
     contactsConfig.contactDetectionThreshold(contactDetectionThreshold_)
         .contactSensorsDisabledInit(contactSensorsDisabledInit)
         .verbose(verbose)
@@ -105,7 +106,7 @@ void NaiveOdometry::configure(const mc_control::MCController & ctl, const mc_rtc
   }
   if(contactsDetectionMethod == LoContactsManager::ContactsDetection::Solver)
   {
-    odometry::LeggedOdometryManager::ContactsManager::ContactsManagerSolverConfiguration contactsConfig(category_);
+    measurements::ContactsManagerSolverConfiguration contactsConfig(category_);
     contactsConfig.contactDetectionThreshold(contactDetectionThreshold_).verbose(verbose);
     odometryManager_.init(ctl, odomConfig, contactsConfig);
   }

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -1,0 +1,953 @@
+#include <mc_control/MCController.h>
+#include <mc_observers/ObserverMacros.h>
+#include <mc_state_observation/TiltObserver.h>
+#include <mc_state_observation/gui_helpers.h>
+#include <mc_state_observation/observersTools/kinematicsTools.h>
+
+namespace mc_state_observation
+{
+
+namespace so = stateObservation;
+
+TiltObserver::TiltObserver(const std::string & type, double dt)
+: mc_observers::Observer(type, dt), estimator_(alpha_, beta_, gamma_)
+{
+  estimator_.setSamplingTime(dt_);
+  xk_.resize(9);
+  xk_ << so::Vector3::Zero(), so::Vector3::Zero(), so::Vector3(0, 0, 1); // so::Vector3(0.49198, 0.66976, 0.55622);
+  estimator_.setState(xk_, 0);
+}
+
+void TiltObserver::configure(const mc_control::MCController & ctl, const mc_rtc::Configuration & config)
+{
+  robot_ = config("robot", ctl.robot().name());
+
+  imuSensor_ = config("imuSensor", ctl.robot().bodySensor().name());
+
+  config("maxAnchorFrameDiscontinuity", maxAnchorFrameDiscontinuity_);
+  config("updateRobot", updateRobot_);
+  config("updateSensor", updateSensor_);
+
+  config("initAlpha", alpha_);
+  config("initBeta", beta_);
+  config("initGamma", gamma_);
+
+  config("finalAlpha", finalAlpha_);
+  config("finalBeta", finalBeta_);
+  config("finalGamma", finalGamma_);
+
+  anchorFrameFunction_ = "KinematicAnchorFrame::" + ctl.robot(robot_).name();
+  // if a user-defined anchor frame function is given, we use it instead
+  if(config.has("anchorFrameFunction"))
+  {
+    if(ctl.datastore().has(anchorFrameFunction_))
+    {
+      anchorFrameFunction_ = config("anchorFrameFunction", name() + "::" + ctl.robot(robot_).name());
+    }
+  }
+
+  std::string typeOfOdometry = static_cast<std::string>(config("odometryType"));
+
+  if(typeOfOdometry == "flatOdometry") { odometryManager_.changeOdometryType(measurements::flatOdometry); }
+  else if(typeOfOdometry == "6dOdometry") { odometryManager_.changeOdometryType(measurements::odometry6d); }
+  else if(typeOfOdometry == "None") { odometryManager_.changeOdometryType(measurements::None); }
+  else
+  {
+    mc_rtc::log::error_and_throw<std::runtime_error>(
+        "Odometry type not allowed. Please pick among : [None, flatOdometry, 6dOdometry]");
+  }
+
+  if(odometryManager_.odometryType_ != measurements::None)
+  {
+    bool velUpdatedUpstream = config("velUpdatedUpstream");
+    bool accUpdatedUpstream = config("accUpdatedUpstream");
+    bool verbose = config("verbose", true);
+    bool withYawEstimation = config("withYawEstimation", true);
+
+    odometryManager_.init(ctl, robot_, observerName_, odometryManager_.odometryType_, withYawEstimation,
+                          velUpdatedUpstream, accUpdatedUpstream, verbose);
+
+    // surfaces used for the contact detection. If the desired detection method doesn't use surfaces, we make sure this
+    // list is not filled in the configuration file to avoid the use of an undesired method.
+    std::vector<std::string> surfacesForContactDetection;
+    config("surfacesForContactDetection", surfacesForContactDetection);
+
+    std::vector<std::string> contactsSensorsDisabledInit =
+        config("contactsSensorDisabledInit", std::vector<std::string>());
+
+    std::string contactsDetection = static_cast<std::string>(config("contactsDetection"));
+
+    LoContactsManager::ContactsDetection contactsDetectionMethod = LoContactsManager::ContactsDetection::undefined;
+    if(contactsDetection == "fromThreshold")
+    {
+      contactsDetectionMethod = LoContactsManager::ContactsDetection::fromThreshold;
+    }
+    else if(contactsDetection == "fromSurfaces")
+    {
+      contactsDetectionMethod = LoContactsManager::ContactsDetection::fromSurfaces;
+    }
+    else if(contactsDetection == "fromSolver")
+    {
+      contactsDetectionMethod = LoContactsManager::ContactsDetection::fromSolver;
+    }
+
+    if(contactsDetectionMethod == LoContactsManager::ContactsDetection::undefined)
+    {
+      mc_rtc::log::error_and_throw<std::runtime_error>(
+          "Contacts detection type not allowed. Please pick among : [fromSolver, fromThreshold, fromSurfaces] or "
+          "initialize a list of surfaces with the variable surfacesForContactDetection");
+    }
+    if(surfacesForContactDetection.size() > 0)
+    {
+      if(contactsDetectionMethod != LoContactsManager::ContactsDetection::fromSurfaces)
+      {
+        mc_rtc::log::error_and_throw<std::runtime_error>(
+            "Another type of contacts detection is currently used, please change it to 'fromSurfaces' or empty the "
+            "surfacesForContactDetection variable");
+      }
+    }
+    else if(contactsDetectionMethod == LoContactsManager::ContactsDetection::fromSurfaces)
+    {
+      mc_rtc::log::error_and_throw<std::runtime_error>(
+          "You selected the contacts detection using surfaces but didn't add the list of surfaces, please add it usign "
+          "the variable surfacesForContactDetection");
+    }
+
+    const auto & robot = ctl.robot(robot_);
+
+    double contactDetectionPropThreshold = config("contactDetectionPropThreshold", 0.11);
+
+    contactDetectionThreshold_ = robot.mass() * so::cst::gravityConstant * contactDetectionPropThreshold;
+
+    if(contactsDetectionMethod == LoContactsManager::ContactsDetection::fromSurfaces)
+    {
+      odometryManager_.initDetection(ctl, robot_, contactsDetectionMethod, surfacesForContactDetection,
+                                     contactsSensorsDisabledInit, contactDetectionThreshold_);
+    }
+    else
+    {
+      std::vector<std::string> forceSensorsToOmit = config("forceSensorsToOmit", std::vector<std::string>());
+
+      odometryManager_.initDetection(ctl, robot_, contactsDetectionMethod, contactsSensorsDisabledInit,
+                                     contactDetectionThreshold_, forceSensorsToOmit);
+    }
+  }
+
+  // check if this observer is used as a backup. If yes we add the backup function to the datastore.
+  config("asBackup", asBackup_);
+  if(asBackup_)
+  {
+    auto & datastore = (const_cast<mc_control::MCController &>(ctl)).datastore();
+
+    datastore.make_call("runBackup", [this, &ctl]() -> const so::kine::Kinematics { return backupFb(ctl); });
+    datastore.make_call("applyLastTransformation",
+                        [this](so::kine::Kinematics & kine) -> so::kine::Kinematics
+                        { return applyLastTransformation(kine); });
+    datastore.make_call("checkCorrectBackupConf",
+                        [this](OdometryType & koOdometryType) { checkCorrectBackupConf(koOdometryType); });
+    datastore.make_call("changeTiltOdometryType",
+                        [this](const std::string & newOdometryType) { changeOdometryType(newOdometryType); });
+  }
+}
+
+void TiltObserver::reset(const mc_control::MCController & ctl)
+{
+  const auto & robot = ctl.robot(robot_);
+  const auto & realRobot = ctl.realRobot(robot_);
+
+  my_robots_ = mc_rbdyn::Robots::make();
+  my_robots_->robotCopy(robot, robot.name());
+
+  // the updated robot has the same floating base's pose than the control robot, but its encoders are updated. We use it
+  // to get more accurate local Kinematics.
+  my_robots_->robotCopy(robot, "updatedRobot");
+  ctl.gui()->addElement(
+      {"Robots"},
+      mc_rtc::gui::Robot("TiltEstimator", [this]() -> const mc_rbdyn::Robot & { return my_robots_->robot(); }));
+  /*
+ctl.gui()->addElement(
+  {"Robots"},
+  mc_rtc::gui::Robot("TiltEstimatorUpdatedRobot", [this]() -> const mc_rbdyn::Robot & { return
+my_robots_->robot("updatedRobot"); }));
+  */
+  const auto & imu = robot.bodySensor(imuSensor_);
+
+  poseW_ = realRobot.posW();
+  velW_ = realRobot.velW();
+  prevPoseW_ = sva::PTransformd::Identity();
+  velW_ = sva::MotionVecd::Zero();
+
+  so::Vector3 tilt; // not exactly the tilt but Rt * ez, corresponding to the Tilt estimator's x1
+  if(imu.linearAcceleration().norm() < 1e-4) { tilt = ctl.robot(robot_).posW().rotation() * so::Vector3::UnitZ(); }
+  else
+  {
+    tilt = imu.linearAcceleration()
+           / imu.linearAcceleration().norm(); // we consider the acceleration as zero on the initialization
+  }
+
+  estimator_.initEstimator(so::Vector3::Zero(), tilt, tilt);
+
+  const Eigen::Matrix3d cOri = (imu.X_b_s() * ctl.robot(robot_).bodyPosW(imu.parentBody())).rotation();
+  so::Vector3 initX2 = cOri * so::Vector3::UnitZ(); // so::kine::rotationMatrixToRotationVector(cOri.transpose());
+
+  estimator_.initEstimator(so::Vector3::Zero(), initX2, initX2);
+
+  /* Initialization of the variables */
+  X_0_C_ = sva::PTransformd::Identity();
+  X_0_C_updated_ = sva::PTransformd::Identity();
+  X_0_C_updated_previous_ = sva::PTransformd::Identity();
+  worldAnchorKine_ = stateObservation::kine::Kinematics::zeroKinematics(flagPoseVels_);
+  updatedWorldAnchorKine_ = stateObservation::kine::Kinematics::zeroKinematics(flagPoseVels_);
+  updatedImuAnchorKine_ = stateObservation::kine::Kinematics::zeroKinematics(flagPoseVels_);
+  anchorFrameJumped_ = false;
+  iter_ = 0;
+  imuVelC_ = sva::MotionVecd::Zero();
+  X_C_IMU_ = sva::PTransformd::Identity();
+
+  // we check if this estimator is used as a backup of the Kinetics Observer
+  if(asBackup_)
+  {
+    // BOOST_ASSERT(withOdometry_ && "The odometry must be used to perform backup");
+    int backupIterInterval = ctl.datastore().get<int>("koBackupIterInterval");
+
+    backupFbKinematics_.resize(backupIterInterval);
+    ctl.gui()->addElement({"OdometryBackup"}, mc_rtc::gui::Button("OdometryBackup", [this, &ctl]() { backupFb(ctl); }));
+  }
+}
+
+bool TiltObserver::run(const mc_control::MCController & ctl)
+{
+  const auto & robot = ctl.robot(robot_);
+  const auto & realRobot = ctl.realRobot(robot_);
+  auto & logger = (const_cast<mc_control::MCController &>(ctl)).logger();
+
+  std::vector<double> q0 = robot.mbc().q[0];
+  my_robots_->robot("updatedRobot").mbc().q = realRobot.mbc().q;
+  my_robots_->robot("updatedRobot").mbc().q[0] = q0;
+
+  my_robots_->robot("updatedRobot").forwardKinematics();
+  my_robots_->robot("updatedRobot").forwardVelocity();
+
+  if(logger.t() > 1.0)
+  {
+    alpha_ = finalAlpha_;
+    beta_ = finalBeta_;
+    gamma_ = finalGamma_;
+  }
+
+  if(odometryManager_.odometryType_ == measurements::None) { runTiltEstimator(ctl, my_robots_->robot("updatedRobot")); }
+  else { runTiltEstimator(ctl, odometryManager_.odometryRobot()); }
+
+  iter_++;
+
+  /* Update of the observed robot */
+  my_robots_->robot().mbc().q = realRobot.mbc().q;
+  update(my_robots_->robot());
+
+  return true;
+}
+
+void TiltObserver::updateAnchorFrame(const mc_control::MCController & ctl, const mc_rbdyn::Robot & updatedRobot)
+{
+  // update of the pose of the anchor frame of the control and updatedRobot in the world.
+  if(odometryManager_.odometryType_ != measurements::None)
+  {
+    // we compute the anchor frame using the lastly computed floating base so we use the previous encoders information.
+    // we use the current force sensors reading.
+    updateAnchorFrameOdometry(ctl);
+    // newWorldAnchorKine_ is already updated in updateAnchorFrameOdometry()
+    newUpdatedWorldAnchorKine_ = newWorldAnchorKine_;
+  }
+  else
+  {
+    updateAnchorFrameNoOdometry(ctl, updatedRobot);
+    // new pose of the anchor frame in the world.
+    newWorldAnchorKine_ = kinematicsTools::poseFromSva(X_0_C_, so::kine::Kinematics::Flags::pose);
+    newUpdatedWorldAnchorKine_ = kinematicsTools::poseFromSva(X_0_C_updated_, so::kine::Kinematics::Flags::pose);
+  }
+
+  /*
+  if(iter_ > itersBeforeAnchorsVel_)
+  { // Check whether anchor frame jumped
+    auto error = (X_0_C_.translation() - worldAnchorKine_.position()).norm();
+    if(error > maxAnchorFrameDiscontinuity_)
+    {
+      mc_rtc::log::warning("[{}] Control anchor frame jumped from [{}] to [{}] (error norm {} > threshold {})", name(),
+                           MC_FMT_STREAMED(worldAnchorKine_.position().transpose()),
+                           MC_FMT_STREAMED(X_0_C_.translation().transpose()), error, maxAnchorFrameDiscontinuity_);
+      anchorFrameJumped_ = true;
+    }
+    auto errorUpdated = (X_0_C_updated_.translation() - updatedWorldAnchorKine_.position()).norm();
+    if(errorUpdated > maxAnchorFrameDiscontinuity_)
+    {
+      mc_rtc::log::warning("[{}] Updated anchor frame jumped from [{}] to [{}] (error norm {:.3f} > threshold {:.3f})",
+                           name(), MC_FMT_STREAMED(X_0_C_updated_previous_.translation().transpose()),
+                           MC_FMT_STREAMED(X_0_C_updated_.translation().transpose()), errorUpdated,
+                           maxAnchorFrameDiscontinuity_);
+      anchorFrameJumped_ = true;
+    }
+  }
+  */
+
+  X_0_C_updated_previous_ = X_0_C_updated_;
+
+  // the velocities of the anchor frames are computed by finite differences, unless it is given in exceptional cases.
+  worldAnchorKine_.update(newWorldAnchorKine_, ctl.timeStep, flagPoseVels_);
+  updatedWorldAnchorKine_.update(newUpdatedWorldAnchorKine_, ctl.timeStep, flagPoseVels_);
+
+  // we ignore the initial outlier velocities due to the position jump
+  if(iter_ < itersBeforeAnchorsVel_)
+  {
+    worldAnchorKine_.linVel().setZero();
+    worldAnchorKine_.angVel().setZero();
+    updatedWorldAnchorKine_.linVel().setZero();
+    updatedWorldAnchorKine_.angVel().setZero();
+  }
+}
+
+void TiltObserver::updateAnchorFrameOdometry(const mc_control::MCController & ctl)
+{
+  // Generally contains only the pose of the anchor frame, but when no contact is detected, the anchor frame becomes the
+  // frame of the IMU and its velocity is considered as zero. For that transition the one when the anchor frame gets
+  // back "to normal", it will contain the zero velocity.
+  newWorldAnchorKine_ = odometryManager_.getAnchorFramePose(ctl, imuSensor_);
+
+  X_0_C_.translation() = newWorldAnchorKine_.position();
+  X_0_C_.rotation() = newWorldAnchorKine_.orientation.toMatrix3().transpose();
+  X_0_C_updated_ = X_0_C_;
+}
+
+void TiltObserver::updateAnchorFrameNoOdometry(const mc_control::MCController & ctl,
+                                               const mc_rbdyn::Robot & updatedRobot)
+{
+  const auto & robot = ctl.robot(robot_);
+  // const auto & robot = my_robots_->robot("updatedRobot");
+
+  anchorFrameJumped_ = false;
+
+  // We don't use the defautl anchorFrameFunction because the obtained anchor position is in the shape of steps and we
+  // obtain very high velocities when using finite differences
+
+  if(!ctl.datastore().has(anchorFrameFunction_))
+  {
+    double leftFootRatio = robot.indirectSurfaceForceSensor("LeftFootCenter").force().z()
+                           / (robot.indirectSurfaceForceSensor("LeftFootCenter").force().z()
+                              + robot.indirectSurfaceForceSensor("RightFootCenter").force().z());
+
+    X_0_C_ = sva::interpolate(robot.surfacePose("RightFootCenter"), robot.surfacePose("LeftFootCenter"), leftFootRatio);
+    X_0_C_updated_ = sva::interpolate(updatedRobot.surfacePose("RightFootCenter"),
+                                      updatedRobot.surfacePose("LeftFootCenter"), leftFootRatio);
+  }
+  else
+  {
+    X_0_C_ = ctl.datastore().call<sva::PTransformd>(anchorFrameFunction_, robot);
+    X_0_C_updated_ = ctl.datastore().call<sva::PTransformd>(anchorFrameFunction_, updatedRobot);
+  }
+}
+
+void TiltObserver::runTiltEstimator(const mc_control::MCController & ctl, const mc_rbdyn::Robot & updatedRobot)
+{
+  /*
+  For the kinematics of the IMU and anchor frame in the world frame, we use the control robot.
+  For internal kinematics like the anchor frame in the IMU, we use the updated robot whose encoders got updated.
+  */
+  // const auto & robot = my_robots_->robot("updatedRobot");
+  const auto & robot = ctl.robot(robot_);
+
+  estimator_.setAlpha(alpha_);
+  estimator_.setBeta(beta_);
+  estimator_.setGamma(gamma_);
+
+  // updates the anchor frame used by the tilt observer.
+  // If we perform odometry, the control and real robot anchor frame are both the one of the odometry robot.
+  updateAnchorFrame(ctl, updatedRobot);
+
+  // Anchor frame defined w.r.t control robot
+  // XXX what if the feet are being moved by the stabilizer?
+
+  // we want in the anchor frame:
+  // - position of the IMU
+  // - orientation of the IMU
+  // - linear velocity of the imu
+  // - angular velocity of the imu
+  // - linear velocity of the anchor frame in the world of the control robot (derivative?)
+
+  const auto & imu = ctl.robot(robot_).bodySensor(imuSensor_);
+  // const auto & rimu = updatedRobot.bodySensor(imuSensor_);
+
+  // In the case we do odometry, the pose and velocities of the odometry robot are still not updated but the joints are.
+  // It is not a problem as this kinematics object is not used to retrieve global poses and velocities.
+  updatedWorldFbKine_ = kinematicsTools::poseAndVelFromSva(updatedRobot.posW(), updatedRobot.velW(), true);
+
+  // we use the imu object of control robot because the copy of BodySensor objects seems to be incomplete. Anyway we use
+  // it only to get information about the parent body, which is the same with the control robot.
+  const sva::PTransformd & imuXbs = imu.X_b_s();
+
+  so::kine::Kinematics parentImuKine =
+      kinematicsTools::poseFromSva(imuXbs, so::kine::Kinematics::Flags::pose | so::kine::Kinematics::Flags::vel);
+
+  const sva::PTransformd & parentPoseW = robot.bodyPosW(imu.parentBody());
+  const sva::PTransformd & updatedParentPoseW = updatedRobot.bodyPosW(imu.parentBody());
+
+  // Compute velocity of the imu in the control frame
+  auto & v_0_imuParent = robot.mbc().bodyVelW[robot.bodyIndexByName(imu.parentBody())];
+
+  auto & updated_v_0_imuParent = updatedRobot.mbc().bodyVelW[updatedRobot.bodyIndexByName(imu.parentBody())];
+
+  so::kine::Kinematics worldParentKine = kinematicsTools::poseAndVelFromSva(parentPoseW, v_0_imuParent, true);
+  so::kine::Kinematics updatedWorldParentKine =
+      kinematicsTools::poseAndVelFromSva(updatedParentPoseW, updated_v_0_imuParent, true);
+
+  // pose and velocities of the IMU in the world frame
+  worldImuKine_ = worldParentKine * parentImuKine;
+  updatedWorldImuKine_ = updatedWorldParentKine * parentImuKine;
+
+  // pose and velocities of the IMU in the floating base. Use of updated robot to use encoders.
+  updatedFbImuKine_ = updatedWorldFbKine_.getInverse() * updatedWorldImuKine_;
+
+  // new pose of the anchor frame in the IMU frame. The velocity is computed right after because we don't want to use
+  // the one given by mc_rtc.
+  so::kine::Kinematics newUpdatedImuAnchorKine = updatedWorldImuKine_.getInverse() * updatedWorldAnchorKine_;
+
+  // The velocities of the IMU in the world (given by mc_rtc) and the ones of the anchor frame in the world (by finite
+  // differences) are not computed the same way, combining them to get the velocity of the anchor frame in the IMU frame
+  // therefore leads to errors. So we "unset" the erroneous newly compute velocities to compute them by finite
+  // differences from the pose of the anchor frame in the IMU.
+  newUpdatedImuAnchorKine.linVel.set(false);
+  newUpdatedImuAnchorKine.angVel.set(false);
+
+  updatedImuAnchorKine_.update(newUpdatedImuAnchorKine, ctl.timeStep, flagPoseVels_);
+
+  // we ignore the initial outlier velocity due to the position jump
+  // we also reset the velocity of the anchor frame when its computation mode changes.
+  if(iter_ < itersBeforeAnchorsVel_ || newWorldAnchorKine_.linVel.isSet())
+  {
+    updatedImuAnchorKine_.linVel().setZero();
+    updatedImuAnchorKine_.angVel().setZero();
+  }
+
+  so::kine::Kinematics updatedAnchorImuKine = updatedImuAnchorKine_.getInverse();
+
+  auto k = estimator_.getCurrentTime();
+
+  // computation of the local linear velocity of the IMU in the world.
+
+  if(odometryManager_.odometryType_ == measurements::None) // case if we don't use odometry
+  {
+    x1_ = worldImuKine_.orientation.toMatrix3().transpose() * worldAnchorKine_.linVel()
+          - (imu.angularVelocity()).cross(updatedImuAnchorKine_.position()) - updatedImuAnchorKine_.linVel();
+
+    estimator_.setMeasurement(x1_, imu.linearAcceleration(), imu.angularVelocity(), k + 1);
+  }
+  else
+  {
+    // when using the odometry, we use the x1 computed internally by the Tilt Observer
+    estimator_.setSensorPositionInC(updatedAnchorImuKine.position());
+    estimator_.setSensorOrientationInC(updatedAnchorImuKine.orientation.toMatrix3());
+    estimator_.setSensorLinearVelocityInC(updatedAnchorImuKine.linVel());
+    estimator_.setSensorAngularVelocityInC(updatedAnchorImuKine.angVel());
+    estimator_.setControlOriginVelocityInW(worldAnchorKine_.orientation.toMatrix3().transpose()
+                                           * worldAnchorKine_.linVel());
+
+    estimator_.setMeasurement(imu.linearAcceleration(), imu.angularVelocity(), k + 1);
+
+    // If the following variable is set, it means that the mode of computation of the anchor frame changed.
+    if(newWorldAnchorKine_.linVel.isSet())
+    {
+      // The anchor frame can be obtained using 2 ways:
+      // - 1: contacts are detected and can be used
+      // - 2: no contact is detected, the robot is hanging. As we still need an anchor frame for the tilt estimation we
+      // arbitrarily use the frame of the IMU. As we cannot perform odometry anymore as there is no contact, we cannot
+      // obtain the velocity of the IMU. We will then consider it as zero and consider it as constant with the linear
+      // acceleration as zero too.
+      // When switching from one mode to another, we consider x1hat = x1 before the estimation to avoid discontinuities.
+
+      updatedImuAnchorKine_.linVel().setZero();
+      updatedImuAnchorKine_.angVel().setZero();
+
+      if(odometryManager_.prevAnchorFromContacts_)
+      {
+        estimator_.setMeasurement(so::Vector3::Zero(), imu.linearAcceleration(), imu.angularVelocity(), k + 1);
+        // estimator_.setAlpha(0);
+      }
+      else
+      {
+        // estimator_.setAlpha(alpha_);
+      }
+
+      estimator_.resetImuLocVelHat();
+    }
+  }
+
+  // estimation of the state with the complementary filters
+  xk_ = estimator_.getEstimatedState(k + 1);
+
+  // retrieving the estimated Tilt
+  so::Vector3 tilt = xk_.tail(3);
+
+  // Orientation of the imu in the world obtained from the estimated tilt and the yaw of the control robot.
+  // When using odometry, the tilt will be kept but the yaw will be replaced by the one of the odometry robot.
+  estimatedRotationIMU_ = so::kine::mergeTiltWithYawAxisAgnostic(tilt, worldImuKine_.orientation.toMatrix3());
+
+  // Estimated orientation of the floating base in the world (especially the tilt)
+  R_0_fb_ = estimatedRotationIMU_ * updatedFbImuKine_.orientation.toMatrix3().transpose();
+
+  // Once we obtain the tilt (which is required by the legged odometry, estimating only the yaw), we update the pose and
+  // velocities of the floating base
+
+  if(odometryManager_.odometryType_ != measurements::None)
+  {
+    // we can update the estimated pose using odometry. The velocity will be updated later using the estimated local
+    // linear velocity of the IMU.
+    auto & logger = (const_cast<mc_control::MCController &>(ctl)).logger();
+
+    odometryManager_.run(ctl, logger, poseW_, R_0_fb_);
+  }
+
+  updatePoseAndVel(xk_.head(3), imu.angularVelocity());
+  backupFbKinematics_.push_back(poseW_);
+
+  // update the velocities as MotionVecd for the logs
+  imuVelC_.linear() = updatedAnchorImuKine.linVel();
+  imuVelC_.angular() = updatedAnchorImuKine.angVel();
+
+  // update the pose as PTransformd for the logs
+  X_C_IMU_.translation() = updatedAnchorImuKine.position();
+  X_C_IMU_.rotation() = updatedAnchorImuKine.orientation.toMatrix3().transpose();
+}
+
+void TiltObserver::updatePoseAndVel(const so::Vector3 & localWorldImuLinVel, const so::Vector3 & localWorldImuAngVel)
+{
+  // if we use odometry, the pose will already updated in odometryManager_.run(...)
+  if(odometryManager_.odometryType_ == measurements::None)
+  {
+    so::kine::Kinematics updatedFbAnchorKine = updatedWorldFbKine_.getInverse() * updatedWorldAnchorKine_;
+
+    correctedWorldFbKine_.orientation = R_0_fb_;
+    correctedWorldFbKine_.position = worldAnchorKine_.position() - R_0_fb_ * updatedFbAnchorKine.position();
+
+    poseW_.translation() = correctedWorldFbKine_.position();
+    poseW_.rotation() = R_0_fb_.transpose();
+  }
+  else { correctedWorldFbKine_ = kinematicsTools::poseFromSva(poseW_, so::kine::Kinematics::Flags::pose); }
+
+  // we use the newly estimated orientation and local linear velocity of the IMU to obtain the one of the floating base.
+  correctedWorldImuKine_ =
+      correctedWorldFbKine_
+      * updatedFbImuKine_; // corrected pose of the imu in the world. This step is used only to get the
+                           // pose of the IMU in the world that is required for the kinematics composition.
+
+  correctedWorldImuKine_.linVel = correctedWorldImuKine_.orientation * localWorldImuLinVel;
+  correctedWorldImuKine_.angVel = correctedWorldImuKine_.orientation * localWorldImuAngVel;
+
+  correctedWorldFbKine_ = correctedWorldImuKine_ * updatedFbImuKine_.getInverse();
+
+  velW_.linear() = correctedWorldFbKine_.linVel();
+  velW_.angular() = correctedWorldFbKine_.angVel();
+
+  if(odometryManager_.odometryType_ != measurements::None)
+  {
+    // the velocity of the odometry robot was obtained using finite differences. We give it our estimated velocity which
+    // is more accurate.
+    odometryManager_.odometryRobot().velW(velW_);
+  }
+}
+
+void TiltObserver::update(mc_control::MCController & ctl)
+{
+  auto & realRobot = ctl.realRobot(robot_);
+  if(updateRobot_)
+  {
+    update(realRobot);
+    realRobot.forwardKinematics();
+    realRobot.forwardVelocity();
+  }
+
+  if(updateSensor_)
+  {
+    auto & robot = ctl.robot(robot_);
+
+    auto & imu = const_cast<mc_rbdyn::BodySensor &>(robot.bodySensor(imuSensor_));
+    auto & rimu = const_cast<mc_rbdyn::BodySensor &>(realRobot.bodySensor(imuSensor_));
+
+    imu.orientation(Eigen::Quaterniond{estimatedRotationIMU_.transpose()});
+    rimu.orientation(Eigen::Quaterniond{estimatedRotationIMU_.transpose()});
+  }
+}
+
+void TiltObserver::update(mc_rbdyn::Robot & robot)
+{
+  robot.posW(poseW_);
+  robot.velW(velW_);
+}
+
+const so::kine::Kinematics TiltObserver::backupFb(const mc_control::MCController & ctl)
+{
+  // new initial pose of the floating base
+
+  boost::circular_buffer<so::kine::Kinematics> * koBackupFbKinematics =
+      ctl.datastore().get<boost::circular_buffer<so::kine::Kinematics> *>("koBackupFbKinematics");
+  so::kine::Kinematics worldResetKine = *(koBackupFbKinematics->begin());
+
+  // so::kine::Kinematics worldResetKine = so::kine::Kinematics::zeroKinematics(so::kine::Kinematics::Flags::pose);
+
+  // original initial pose of the floating base
+  so::kine::Kinematics worldFbInitBackup =
+      kinematicsTools::poseFromSva(backupFbKinematics_.front(), so::kine::Kinematics::Flags::pose);
+
+  so::kine::Kinematics fbWorldInitBackup = worldFbInitBackup.getInverse();
+
+  // we apply the transformation from the initial pose to the intermediates pose estimated by the tilt estimator to the
+  // new starting pose of the Kinetics Observer
+  for(int i = 0; i < koBackupFbKinematics->size(); i++)
+  {
+    // Intermediary pose of the floating base estimated by the tilt estimator
+    so::kine::Kinematics worldFbIntermBackup =
+        kinematicsTools::poseFromSva(backupFbKinematics_.at(i), so::kine::Kinematics::Flags::pose);
+    // transformation between the initial and the intermediary pose during the backup interval
+    so::kine::Kinematics initInterm = fbWorldInitBackup * worldFbIntermBackup;
+
+    koBackupFbKinematics->at(i) = worldResetKine * initInterm;
+  }
+
+  so::Vector3 tiltLocalLinVel = poseW_.rotation() * velW_.linear();
+  so::Vector3 tiltLocalAngVel = poseW_.rotation() * velW_.angular();
+
+  // koBackupFbKinematics->back() is the new last pose of the kinetics observer
+  koBackupFbKinematics->back().linVel = koBackupFbKinematics->back().orientation.toMatrix3() * tiltLocalLinVel;
+  koBackupFbKinematics->back().angVel = koBackupFbKinematics->back().orientation.toMatrix3() * tiltLocalAngVel;
+
+  return koBackupFbKinematics->back();
+}
+
+so::kine::Kinematics TiltObserver::applyLastTransformation(const so::kine::Kinematics & previousKine)
+{
+  so::kine::Kinematics worldFbPreviousBackup = kinematicsTools::poseFromSva(
+      backupFbKinematics_.at(backupFbKinematics_.size() - 2), so::kine::Kinematics::Flags::pose);
+
+  so::kine::Kinematics fbWorldPreviousBackup = worldFbPreviousBackup.getInverse();
+  so::kine::Kinematics worldFbFinalBackup =
+      kinematicsTools::poseFromSva(backupFbKinematics_.back(), so::kine::Kinematics::Flags::pose);
+
+  so::kine::Kinematics lastTransformation = fbWorldPreviousBackup * worldFbFinalBackup;
+
+  so::kine::Kinematics newKine = previousKine * lastTransformation;
+
+  so::Vector3 tiltLocalLinVel = poseW_.rotation() * velW_.linear();
+  so::Vector3 tiltLocalAngVel = poseW_.rotation() * velW_.angular();
+
+  // koBackupFbKinematics->back() is the new last pose of the kinetics observer
+  newKine.linVel = newKine.orientation.toMatrix3() * tiltLocalLinVel;
+  newKine.angVel = newKine.orientation.toMatrix3() * tiltLocalAngVel;
+
+  return newKine;
+}
+
+void TiltObserver::checkCorrectBackupConf(OdometryType & koOdometryType)
+{
+  static bool wasExecuted = false;
+  if(wasExecuted) { return; }
+  else
+  {
+    if(odometryManager_.odometryType_ != koOdometryType)
+    {
+      mc_rtc::log::error_and_throw<std::runtime_error>("The odometry types used for the Tilt Observer and the Kinetics "
+                                                       "Observer don't match, the backup is not possible.");
+    }
+    wasExecuted = true;
+    return;
+  }
+}
+
+void TiltObserver::changeOdometryType(const std::string & newOdometryType)
+{
+  OdometryType prevOdometryType = odometryManager_.odometryType_;
+  if(newOdometryType == "flatOdometry") { odometryManager_.changeOdometryType(measurements::flatOdometry); }
+  else if(newOdometryType == "6dOdometry") { odometryManager_.changeOdometryType(measurements::odometry6d); }
+
+  if(odometryManager_.odometryType_ != prevOdometryType)
+  {
+    mc_rtc::log::info("[{}]: Odometry mode changed to: {}", observerName_, newOdometryType);
+  }
+}
+
+void TiltObserver::addToLogger(const mc_control::MCController & ctl,
+                               mc_rtc::Logger & logger,
+                               const std::string & category)
+{
+  logger.addLogEntry(category + "_constants_alpha", [this]() -> const double & { return alpha_; });
+  logger.addLogEntry(category + "_constants_beta", [this]() -> const double & { return beta_; });
+  logger.addLogEntry(category + "_constants_gamma", [this]() -> const double & { return gamma_; });
+
+  logger.addLogEntry(category + "_debug_OdometryType",
+                     [this]() -> std::string
+                     {
+                       switch(odometryManager_.odometryType_)
+                       {
+                         case measurements::flatOdometry:
+                           return "flatOdometry";
+                           break;
+                         case measurements::odometry6d:
+                           return "6dOdometry";
+                           break;
+                         case measurements::None:
+                           return "None";
+                           break;
+                       }
+                       return "default";
+                     });
+
+  logger.addLogEntry(category + "_controlAnchorFrame", [this]() -> const sva::PTransformd & { return X_0_C_; });
+  logger.addLogEntry(category + "_updatedRobot",
+                     [this]() -> const sva::PTransformd &
+                     {
+                       const auto & updatedRobot = my_robots_->robot("updatedRobot");
+                       return updatedRobot.posW();
+                     });
+
+  logger.addLogEntry(category + "_IMU_world_orientation",
+                     [this]() { return Eigen::Quaterniond{estimatedRotationIMU_}; });
+  logger.addLogEntry(category + "_IMU_world_localLinVel", [this]() -> so::Vector3 { return xk_.head(3); });
+  logger.addLogEntry(category + "_IMU_AnchorFrame_pose", [this]() -> const sva::PTransformd & { return X_C_IMU_; });
+  logger.addLogEntry(category + "_IMU_AnchorFrame_linVel", [this]() -> const sva::MotionVecd & { return imuVelC_; });
+  logger.addLogEntry(category + "_AnchorFrame_world_position",
+                     [this]() -> so::Vector3 { return worldAnchorKine_.position(); });
+  logger.addLogEntry(category + "_AnchorFrame_world_orientation",
+                     [this]() -> so::Vector3 { return worldAnchorKine_.orientation.toRotationVector(); });
+  logger.addLogEntry(category + "_AnchorFrame_world_linVel_global",
+                     [this]() -> so::Vector3 { return worldAnchorKine_.linVel(); });
+  logger.addLogEntry(category + "_AnchorFrame_world_linVel_local",
+                     [this]() -> so::Vector3
+                     { return worldAnchorKine_.orientation.toMatrix3().transpose() * worldAnchorKine_.linVel(); });
+  logger.addLogEntry(category + "_AnchorFrame_world_angVel",
+                     [this]() -> const so::Vector3 & { return worldAnchorKine_.angVel(); });
+  logger.addLogEntry(category + "_FloatingBase_world_pose", [this]() -> const sva::PTransformd & { return poseW_; });
+  logger.addLogEntry(category + "_FloatingBase_world_vel", [this]() -> const sva::MotionVecd & { return velW_; });
+  logger.addLogEntry(category + "_debug_x1", [this]() -> const so::Vector3 & { return x1_; });
+
+  logger.addLogEntry(category + "_debug_realWorldImuLocAngVel",
+                     [this, &ctl]() -> so::Vector3
+                     {
+                       const sva::PTransformd & realImuXbs = ctl.realRobot(robot_).bodySensor(imuSensor_).X_b_s();
+
+                       so::kine::Kinematics realParentImuKine = kinematicsTools::poseFromSva(
+                           realImuXbs, so::kine::Kinematics::Flags::pose | so::kine::Kinematics::Flags::vel);
+
+                       const sva::PTransformd & realParentPoseW =
+                           ctl.realRobot(robot_).bodyPosW(ctl.realRobot(robot_).bodySensor(imuSensor_).parentBody());
+
+                       // Compute velocity of the imu in the control frame
+                       auto & real_v_0_imuParent =
+                           ctl.realRobot(robot_).mbc().bodyVelW[ctl.realRobot(robot_).bodyIndexByName(
+                               ctl.realRobot(robot_).bodySensor(imuSensor_).parentBody())];
+
+                       so::kine::Kinematics realWorldParentKine =
+                           kinematicsTools::poseAndVelFromSva(realParentPoseW, real_v_0_imuParent, true);
+
+                       so::kine::Kinematics realWorldImuKine_ = realWorldParentKine * realParentImuKine;
+
+                       return realWorldImuKine_.orientation.toMatrix3().transpose() * realWorldImuKine_.angVel();
+                     });
+
+  logger.addLogEntry(category + "_debug_ctlWorldImuLocAngVel",
+                     [this, &ctl]() -> so::Vector3
+                     {
+                       const sva::PTransformd & imuXbs = ctl.robot(robot_).bodySensor(imuSensor_).X_b_s();
+
+                       so::kine::Kinematics parentImuKine = kinematicsTools::poseFromSva(
+                           imuXbs, so::kine::Kinematics::Flags::pose | so::kine::Kinematics::Flags::vel);
+
+                       const sva::PTransformd & parentPoseW =
+                           ctl.robot(robot_).bodyPosW(ctl.robot(robot_).bodySensor(imuSensor_).parentBody());
+
+                       // Compute velocity of the imu in the control frame
+                       auto & v_0_imuParent = ctl.robot(robot_).mbc().bodyVelW[ctl.robot(robot_).bodyIndexByName(
+                           ctl.robot(robot_).bodySensor(imuSensor_).parentBody())];
+
+                       so::kine::Kinematics worldParentKine =
+                           kinematicsTools::poseAndVelFromSva(parentPoseW, v_0_imuParent, true);
+
+                       so::kine::Kinematics worldImuKine_ = worldParentKine * parentImuKine;
+
+                       return worldImuKine_.orientation.toMatrix3().transpose() * worldImuKine_.angVel();
+                     });
+
+  logger.addLogEntry(category + "_debug_ctlWorldAnchorVelExpressedInImu",
+                     [this, &ctl]() -> so::Vector3
+                     {
+                       const auto & robot = ctl.robot(robot_);
+
+                       const auto & imu = robot.bodySensor(imuSensor_);
+                       const sva::PTransformd & imuXbs = imu.X_b_s();
+
+                       return imuXbs.rotation() * worldAnchorKine_.linVel();
+                     });
+
+  logger.addLogEntry(
+      category + "_debug_updatedWorldAnchorVelExpressedInImu",
+      [this]() -> so::Vector3
+      { return updatedWorldImuKine_.orientation.toMatrix3().transpose() * updatedWorldAnchorKine_.linVel(); });
+
+  logger.addLogEntry(category + "_debug_realX1",
+                     [this, &ctl]() -> so::Vector3
+                     {
+                       const auto & realRobot = ctl.realRobot(robot_);
+                       const auto & rimu = realRobot.bodySensor(imuSensor_);
+
+                       const sva::PTransformd & rimuXbs = rimu.X_b_s();
+
+                       so::kine::Kinematics parentImuKine = kinematicsTools::poseFromSva(
+                           rimuXbs, so::kine::Kinematics::Flags::pose | so::kine::Kinematics::Flags::vel);
+
+                       const sva::PTransformd & parentPoseW = realRobot.bodyPosW(rimu.parentBody());
+
+                       // Compute velocity of the imu in the control frame
+                       auto & v_0_imuParent = realRobot.mbc().bodyVelW[realRobot.bodyIndexByName(rimu.parentBody())];
+
+                       so::kine::Kinematics worldParentKine =
+                           kinematicsTools::poseAndVelFromSva(parentPoseW, v_0_imuParent, true);
+
+                       so::kine::Kinematics worldImuKine = worldParentKine * parentImuKine;
+                       return worldImuKine.orientation.toMatrix3().transpose() * worldImuKine.linVel();
+                     });
+
+  logger.addLogEntry(category + "_debug_realImuVel",
+                     [this, &ctl]() -> so::Vector3
+                     {
+                       const auto & realRobot = ctl.realRobot(robot_);
+                       const auto & rimu = realRobot.bodySensor(imuSensor_);
+
+                       const sva::PTransformd & rimuXbs = rimu.X_b_s();
+
+                       so::kine::Kinematics parentImuKine = kinematicsTools::poseFromSva(
+                           rimuXbs, so::kine::Kinematics::Flags::pose | so::kine::Kinematics::Flags::vel);
+
+                       const sva::PTransformd & parentPoseW = realRobot.bodyPosW(rimu.parentBody());
+
+                       auto & v_0_imuParent = realRobot.mbc().bodyVelW[realRobot.bodyIndexByName(rimu.parentBody())];
+
+                       so::kine::Kinematics worldParentKine =
+                           kinematicsTools::poseAndVelFromSva(parentPoseW, v_0_imuParent, true);
+
+                       so::kine::Kinematics worldImuKine = worldParentKine * parentImuKine;
+                       return worldImuKine.linVel();
+                     });
+
+  logger.addLogEntry(category + "_debug_realBodyVel",
+                     [this, &ctl]() -> so::Vector3
+                     {
+                       const auto & realRobot = ctl.realRobot(robot_);
+                       const auto & rimu = realRobot.bodySensor(imuSensor_);
+
+                       return realRobot.mbc().bodyVelW[realRobot.bodyIndexByName(rimu.parentBody())].linear();
+                     });
+
+  logger.addLogEntry(category + "_debug_ctlX1",
+                     [this, &ctl]() -> so::Vector3
+                     {
+                       const auto & robot = ctl.robot(robot_);
+                       const auto & imu = robot.bodySensor(imuSensor_);
+
+                       const sva::PTransformd & imuXbs = imu.X_b_s();
+
+                       so::kine::Kinematics parentImuKine = kinematicsTools::poseFromSva(
+                           imuXbs, so::kine::Kinematics::Flags::pose | so::kine::Kinematics::Flags::vel);
+
+                       const sva::PTransformd & parentPoseW = robot.bodyPosW(imu.parentBody());
+
+                       // Compute velocity of the imu in the control frame
+                       auto & v_0_imuParent = robot.mbc().bodyVelW[robot.bodyIndexByName(imu.parentBody())];
+
+                       so::kine::Kinematics worldParentKine =
+                           kinematicsTools::poseAndVelFromSva(parentPoseW, v_0_imuParent, true);
+
+                       so::kine::Kinematics worldImuKine = worldParentKine * parentImuKine;
+                       return worldImuKine.orientation.toMatrix3().transpose() * worldImuKine.linVel();
+                     });
+
+  logger.addLogEntry(category + "_debug_ctlImuVel",
+                     [this, &ctl]() -> so::Vector3
+                     {
+                       const auto & robot = ctl.robot(robot_);
+                       const auto & imu = robot.bodySensor(imuSensor_);
+
+                       const sva::PTransformd & imuXbs = imu.X_b_s();
+
+                       so::kine::Kinematics parentImuKine = kinematicsTools::poseFromSva(
+                           imuXbs, so::kine::Kinematics::Flags::pose | so::kine::Kinematics::Flags::vel);
+
+                       const sva::PTransformd & parentPoseW = robot.bodyPosW(imu.parentBody());
+
+                       auto & v_0_imuParent = robot.mbc().bodyVelW[robot.bodyIndexByName(imu.parentBody())];
+
+                       so::kine::Kinematics worldParentKine =
+                           kinematicsTools::poseAndVelFromSva(parentPoseW, v_0_imuParent, true);
+
+                       so::kine::Kinematics worldImuKine = worldParentKine * parentImuKine;
+                       return worldImuKine.linVel();
+                     });
+
+  logger.addLogEntry(category + "_debug_contactDetected",
+                     [this]() -> std::string
+                     {
+                       if(odometryManager_.contactsManager().contactsFound().size() > 0) { return "contacts"; }
+                       else { return "no contacts"; }
+                     });
+
+  logger.addLogEntry(category + "_debug_ctlBodyVel",
+                     [this, &ctl]() -> so::Vector3
+                     {
+                       const auto & robot = ctl.robot(robot_);
+                       const auto & imu = robot.bodySensor(imuSensor_);
+
+                       return robot.mbc().bodyVelW[robot.bodyIndexByName(imu.parentBody())].linear();
+                     });
+
+  kinematicsTools::addToLogger(worldAnchorKine_, logger, category + "_debug_worldAnchorKine");
+  kinematicsTools::addToLogger(updatedWorldImuKine_, logger, category + "_debug_updatedWorldImuKine");
+  kinematicsTools::addToLogger(worldImuKine_, logger, category + "_debug_worldImuKine");
+  kinematicsTools::addToLogger(updatedWorldAnchorKine_, logger, category + "_debug_updatedWorldAnchorKine");
+  kinematicsTools::addToLogger(updatedImuAnchorKine_, logger, category + "_debug_updatedImuAnchorKine_");
+  logger.addLogEntry(category + "_debug_ctlImuAnchorKine.linVel()",
+                     [this]() -> so::Vector3
+                     {
+                       so::kine::Kinematics imuAnchorKine = worldImuKine_.getInverse() * worldAnchorKine_;
+                       return imuAnchorKine.linVel();
+                     });
+
+  kinematicsTools::addToLogger(updatedWorldFbKine_, logger, category + "_debug_updatedWorldFbKine_");
+  kinematicsTools::addToLogger(correctedWorldImuKine_, logger, category + "_debug_correctedWorldImuKine_");
+}
+
+void TiltObserver::removeFromLogger(mc_rtc::Logger & logger, const std::string & category)
+{
+  logger.removeLogEntry(category + "_imuVelC");
+  logger.removeLogEntry(category + "_imuPoseC");
+  logger.removeLogEntry(category + "_imuEstRotW");
+  logger.removeLogEntry(category + "_controlAnchorFrame");
+}
+
+void TiltObserver::addToGUI(const mc_control::MCController &,
+                            mc_rtc::gui::StateBuilder & gui,
+                            const std::vector<std::string> & category)
+{
+  using namespace mc_state_observation::gui;
+  gui.addElement(category, make_input_element("alpha", alpha_), make_input_element("beta", beta_),
+                 make_input_element("gamma", gamma_));
+
+  if(odometryManager_.odometryType_ != measurements::None)
+  {
+    gui.addElement({observerName_, "Odometry"},
+                   mc_rtc::gui::ComboInput(
+                       "Choose from list", {"6dOdometry", "flatOdometry"},
+                       [this]() -> std::string
+                       {
+                         if(odometryManager_.odometryType_ == measurements::flatOdometry) { return "flatOdometry"; }
+                         else { return "6dOdometry"; }
+                       },
+                       [this](const std::string & typeOfOdometry) { changeOdometryType(typeOfOdometry); }));
+  }
+}
+
+} // namespace mc_state_observation
+EXPORT_OBSERVER_MODULE("Tilt", mc_state_observation::TiltObserver)

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -606,9 +606,9 @@ void TiltObserver::addToLogger(const mc_control::MCController & ctl,
                                mc_rtc::Logger & logger,
                                const std::string & category)
 {
-  logger.addLogEntry(category + "_constants_alpha", [this]() -> const double & { return alpha_; });
-  logger.addLogEntry(category + "_constants_beta", [this]() -> const double & { return beta_; });
-  logger.addLogEntry(category + "_constants_gamma", [this]() -> const double & { return gamma_; });
+  logger.addLogEntry(category + "_constants_alpha", [this]() -> double { return estimator_.getAlpha(); });
+  logger.addLogEntry(category + "_constants_beta", [this]() -> double { return estimator_.getBeta(); });
+  logger.addLogEntry(category + "_constants_gamma", [this]() -> double { return estimator_.getGamma(); });
 
   logger.addLogEntry(category + "_debug_OdometryType",
                      [this]() -> std::string

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -903,11 +903,11 @@ void TiltObserver::addToLogger(const mc_control::MCController & ctl,
                        return robot.mbc().bodyVelW[robot.bodyIndexByName(imu.parentBody())].linear();
                      });
 
-  conversions::kinematics::addToLogger(worldAnchorKine_, logger, category + "_debug_worldAnchorKine");
-  conversions::kinematics::addToLogger(updatedWorldImuKine_, logger, category + "_debug_updatedWorldImuKine");
-  conversions::kinematics::addToLogger(worldImuKine_, logger, category + "_debug_worldImuKine");
-  conversions::kinematics::addToLogger(updatedWorldAnchorKine_, logger, category + "_debug_updatedWorldAnchorKine");
-  conversions::kinematics::addToLogger(updatedImuAnchorKine_, logger, category + "_debug_updatedImuAnchorKine_");
+  conversions::kinematics::addToLogger(logger, worldAnchorKine_, category + "_debug_worldAnchorKine");
+  conversions::kinematics::addToLogger(logger, updatedWorldImuKine_, category + "_debug_updatedWorldImuKine");
+  conversions::kinematics::addToLogger(logger, worldImuKine_, category + "_debug_worldImuKine");
+  conversions::kinematics::addToLogger(logger, updatedWorldAnchorKine_, category + "_debug_updatedWorldAnchorKine");
+  conversions::kinematics::addToLogger(logger, updatedImuAnchorKine_, category + "_debug_updatedImuAnchorKine_");
   logger.addLogEntry(category + "_debug_ctlImuAnchorKine.linVel()",
                      [this]() -> so::Vector3
                      {
@@ -915,8 +915,8 @@ void TiltObserver::addToLogger(const mc_control::MCController & ctl,
                        return imuAnchorKine.linVel();
                      });
 
-  conversions::kinematics::addToLogger(updatedWorldFbKine_, logger, category + "_debug_updatedWorldFbKine_");
-  conversions::kinematics::addToLogger(correctedWorldImuKine_, logger, category + "_debug_correctedWorldImuKine_");
+  conversions::kinematics::addToLogger(logger, updatedWorldFbKine_, category + "_debug_updatedWorldFbKine_");
+  conversions::kinematics::addToLogger(logger, correctedWorldImuKine_, category + "_debug_correctedWorldImuKine_");
 }
 
 void TiltObserver::removeFromLogger(mc_rtc::Logger & logger, const std::string & category)

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -1,9 +1,9 @@
-#include <mc_control/MCController.h>
 #include <mc_observers/ObserverMacros.h>
-// #include "mc_state_observation/measurements/measurementsTools.h"
+
 #include <mc_state_observation/TiltObserver.h>
-#include <mc_state_observation/conversions/kinematics.h>
 #include <mc_state_observation/gui_helpers.h>
+
+#include <mc_state_observation/conversions/kinematics.h>
 
 namespace mc_state_observation
 {

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -408,6 +408,7 @@ void TiltObserver::runTiltEstimator(const mc_control::MCController & ctl, const 
                                            * worldAnchorKine_.linVel());
 
     estimator_.setMeasurement(imu.linearAcceleration(), imu.angularVelocity(), k + 1);
+    x1_ = estimator_.getVirtualLocalVelocityMeasurement();
 
     // If the following variable is set, it means that the mode of computation of the anchor frame changed.
     if(newWorldAnchorKine_.linVel.isSet())
@@ -426,6 +427,7 @@ void TiltObserver::runTiltEstimator(const mc_control::MCController & ctl, const 
       if(odometryManager_.prevAnchorFromContacts_)
       {
         estimator_.setMeasurement(so::Vector3::Zero(), imu.linearAcceleration(), imu.angularVelocity(), k + 1);
+        x1_ = estimator_.getVirtualLocalVelocityMeasurement();
         // estimator_.setAlpha(0);
       }
       else

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -176,9 +176,14 @@ bool TiltObserver::run(const mc_control::MCController & ctl)
   const auto & realRobot = ctl.realRobot(robot_);
   auto & logger = (const_cast<mc_control::MCController &>(ctl)).logger();
 
-  std::vector<double> q0 = robot.mbc().q[0];
-  my_robots_->robot("updatedRobot").mbc().q = realRobot.mbc().q;
-  my_robots_->robot("updatedRobot").mbc().q[0] = q0;
+  const auto & realQ = realRobot.mbc().q;
+  const auto & realAlpha = realRobot.mbc().alpha;
+
+  std::copy(std::next(realQ.begin()), realQ.end(), std::next(my_robots_->robot("updatedRobot").mbc().q.begin()));
+  std::copy(std::next(realAlpha.begin()), realAlpha.end(),
+            std::next(my_robots_->robot("updatedRobot").mbc().alpha.begin()));
+  my_robots_->robot("updatedRobot").mbc().q[0] = robot.mbc().q[0];
+  my_robots_->robot("updatedRobot").mbc().alpha[0] = robot.mbc().alpha[0];
 
   my_robots_->robot("updatedRobot").forwardKinematics();
   my_robots_->robot("updatedRobot").forwardVelocity();

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -931,10 +931,7 @@ void TiltObserver::addToLogger(const mc_control::MCController & ctl,
 
   logger.addLogEntry(category + "_debug_contactDetected",
                      [this]() -> std::string
-                     {
-                       if(odometryManager_.contactsManager().contactsFound().size() > 0) { return "contacts"; }
-                       else { return "no contacts"; }
-                     });
+                     { return odometryManager_.contactsManager().contactsDetected() ? "contacts" : "no contacts"; });
 
   logger.addLogEntry(category + "_debug_ctlBodyVel",
                      [this, &ctl]() -> so::Vector3

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -14,20 +14,16 @@ namespace so = stateObservation;
 using OdometryType = measurements::OdometryType;
 using LoContactsManager = odometry::LeggedOdometryManager::ContactsManager;
 
-TiltObserver::TiltObserver(const std::string & type, double dt)
-: mc_observers::Observer(type, dt), estimator_(alpha_, beta_, gamma_)
+TiltObserver::TiltObserver(const std::string & type, double dt, bool asBackup, const std::string & observerName)
+: mc_observers::Observer(type, dt), estimator_(alpha_, beta_, gamma_), odometryManager_(observerName)
 {
   estimator_.setSamplingTime(dt_);
   xk_.resize(9);
   xk_ << so::Vector3::Zero(), so::Vector3::Zero(), so::Vector3(0, 0, 1); // so::Vector3(0.49198, 0.66976, 0.55622);
   estimator_.setState(xk_, 0);
-}
 
-TiltObserver::TiltObserver(const std::string & type, double dt, bool asBackup, const std::string & categoryPrefix)
-: TiltObserver(type, dt)
-{
   asBackup_ = asBackup;
-  observerName_ = categoryPrefix + observerName_;
+  observerName_ = observerName;
 }
 
 void TiltObserver::configure(const mc_control::MCController & ctl, const mc_rtc::Configuration & config)

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -77,7 +77,7 @@ void TiltObserver::configure(const mc_control::MCController & ctl, const mc_rtc:
 
     std::string contactsDetectionString = static_cast<std::string>(config("contactsDetection"));
     LoContactsManager::ContactsDetection contactsDetectionMethod =
-        odometryManager_.contactsManager().stringToContactsDetection(contactsDetectionString);
+        odometryManager_.contactsManager().stringToContactsDetection(contactsDetectionString, observerName_);
 
     if(surfacesForContactDetection.size() > 0
        && contactsDetectionMethod != LoContactsManager::ContactsDetection::Surfaces)
@@ -94,7 +94,7 @@ void TiltObserver::configure(const mc_control::MCController & ctl, const mc_rtc:
     contactDetectionThreshold_ = robot.mass() * so::cst::gravityConstant * contactDetectionPropThreshold;
 
     odometry::LeggedOdometryManager::Configuration odomConfig(robot_, observerName_, odometryManager_.odometryType_);
-    odomConfig.velocityUpdate(odometry::LeggedOdometryManager::noUpdate)
+    odomConfig.velocityUpdate(odometry::LeggedOdometryManager::VelocityUpdate::NoUpdate)
         .withModeSwitchInGui(false)
         .withYawEstimation(withYawEstimation);
 

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -860,7 +860,7 @@ void TiltObserver::addToGUI(const mc_control::MCController &,
 
   // we allow to change the odometry type if the Tilt Observer is not used as a backup of the Kinetics Observer.
   // Otherwise the type can be changed by changing the one of the Kinetics Observer.
-  if(asBackup_ != true)
+  if(asBackup_ != true && odometryManager_.odometryType_ != measurements::OdometryType::None)
   {
     gui.addElement({observerName_, "Odometry"},
                    mc_rtc::gui::ComboInput(

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -49,16 +49,12 @@ void TiltObserver::configure(const mc_control::MCController & ctl, const mc_rtc:
 
   std::string typeOfOdometry = static_cast<std::string>(config("odometryType"));
 
-  if(typeOfOdometry == "flatOdometry") { odometryManager_.changeOdometryType(measurements::OdometryType::Flat); }
-  else if(typeOfOdometry == "6dOdometry")
-  {
-    odometryManager_.changeOdometryType(measurements::OdometryType::Odometry6d);
-  }
+  if(typeOfOdometry == "Flat") { odometryManager_.changeOdometryType(measurements::OdometryType::Flat); }
+  else if(typeOfOdometry == "6D") { odometryManager_.changeOdometryType(measurements::OdometryType::Odometry6d); }
   else if(typeOfOdometry == "None") { odometryManager_.changeOdometryType(measurements::OdometryType::None); }
   else
   {
-    mc_rtc::log::error_and_throw<std::runtime_error>(
-        "Odometry type not allowed. Please pick among : [None, flatOdometry, 6dOdometry]");
+    mc_rtc::log::error_and_throw<std::runtime_error>("Odometry type not allowed. Please pick among : [None, Flat, 6D]");
   }
 
   if(odometryManager_.odometryType_ != measurements::OdometryType::None)
@@ -82,18 +78,12 @@ void TiltObserver::configure(const mc_control::MCController & ctl, const mc_rtc:
     std::string contactsDetection = static_cast<std::string>(config("contactsDetection"));
 
     LoContactsManager::ContactsDetection contactsDetectionMethod = LoContactsManager::ContactsDetection::Undefined;
-    if(contactsDetection == "fromThreshold")
-    {
-      contactsDetectionMethod = LoContactsManager::ContactsDetection::Sensors;
-    }
-    else if(contactsDetection == "fromSurfaces")
+    if(contactsDetection == "Sensors") { contactsDetectionMethod = LoContactsManager::ContactsDetection::Sensors; }
+    else if(contactsDetection == "Surfaces")
     {
       contactsDetectionMethod = LoContactsManager::ContactsDetection::Surfaces;
     }
-    else if(contactsDetection == "fromSolver")
-    {
-      contactsDetectionMethod = LoContactsManager::ContactsDetection::Solver;
-    }
+    else if(contactsDetection == "Solver") { contactsDetectionMethod = LoContactsManager::ContactsDetection::Solver; }
 
     if(contactsDetectionMethod == LoContactsManager::ContactsDetection::Undefined)
     {
@@ -669,11 +659,8 @@ void TiltObserver::checkCorrectBackupConf(OdometryType & koOdometryType)
 void TiltObserver::changeOdometryType(const std::string & newOdometryType)
 {
   OdometryType prevOdometryType = odometryManager_.odometryType_;
-  if(newOdometryType == "flatOdometry") { odometryManager_.changeOdometryType(measurements::OdometryType::Flat); }
-  else if(newOdometryType == "6dOdometry")
-  {
-    odometryManager_.changeOdometryType(measurements::OdometryType::Odometry6d);
-  }
+  if(newOdometryType == "Flat") { odometryManager_.changeOdometryType(measurements::OdometryType::Flat); }
+  else if(newOdometryType == "6D") { odometryManager_.changeOdometryType(measurements::OdometryType::Odometry6d); }
 
   if(odometryManager_.odometryType_ != prevOdometryType)
   {
@@ -695,10 +682,10 @@ void TiltObserver::addToLogger(const mc_control::MCController & ctl,
                        switch(odometryManager_.odometryType_)
                        {
                          case measurements::OdometryType::Flat:
-                           return "flatOdometry";
+                           return "Flat";
                            break;
                          case measurements::OdometryType::Odometry6d:
-                           return "6dOdometry";
+                           return "6D";
                            break;
                          case measurements::OdometryType::None:
                            return "None";
@@ -949,14 +936,11 @@ void TiltObserver::addToGUI(const mc_control::MCController &,
   {
     gui.addElement({observerName_, "Odometry"},
                    mc_rtc::gui::ComboInput(
-                       "Choose from list", {"6dOdometry", "flatOdometry"},
+                       "Choose from list", {"6D", "Flat"},
                        [this]() -> std::string
                        {
-                         if(odometryManager_.odometryType_ == measurements::OdometryType::Flat)
-                         {
-                           return "flatOdometry";
-                         }
-                         else { return "6dOdometry"; }
+                         if(odometryManager_.odometryType_ == measurements::OdometryType::Flat) { return "Flat"; }
+                         else { return "6D"; }
                        },
                        [this](const std::string & typeOfOdometry) { changeOdometryType(typeOfOdometry); }));
   }

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -87,9 +87,6 @@ void TiltObserver::configure(const mc_control::MCController & ctl, const mc_rtc:
                                                        "surfacesForContactDetection variable");
     }
 
-    std::vector<std::string> contactSensorsDisabledInit =
-        config("contactsSensorDisabledInit", std::vector<std::string>());
-
     double contactDetectionPropThreshold = config("contactDetectionPropThreshold", 0.11);
     contactDetectionThreshold_ = robot.mass() * so::cst::gravityConstant * contactDetectionPropThreshold;
 
@@ -101,9 +98,7 @@ void TiltObserver::configure(const mc_control::MCController & ctl, const mc_rtc:
     if(contactsDetectionMethod == LoContactsManager::ContactsDetection::Surfaces)
     {
       measurements::ContactsManagerSurfacesConfiguration contactsConfig(observerName_, surfacesForContactDetection);
-      contactsConfig.contactDetectionThreshold(contactDetectionThreshold_)
-          .contactSensorsDisabledInit(contactSensorsDisabledInit)
-          .verbose(verbose);
+      contactsConfig.contactDetectionThreshold(contactDetectionThreshold_).verbose(verbose);
       odometryManager_.init(ctl, odomConfig, contactsConfig);
     }
     if(contactsDetectionMethod == LoContactsManager::ContactsDetection::Sensors)
@@ -112,7 +107,6 @@ void TiltObserver::configure(const mc_control::MCController & ctl, const mc_rtc:
 
       measurements::ContactsManagerSensorsConfiguration contactsConfig(observerName_);
       contactsConfig.contactDetectionThreshold(contactDetectionThreshold_)
-          .contactSensorsDisabledInit(contactSensorsDisabledInit)
           .verbose(verbose)
           .forceSensorsToOmit(forceSensorsToOmit);
       odometryManager_.init(ctl, odomConfig, contactsConfig);

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -108,8 +108,7 @@ void TiltObserver::configure(const mc_control::MCController & ctl, const mc_rtc:
 
     if(contactsDetectionMethod == LoContactsManager::ContactsDetection::Surfaces)
     {
-      odometry::LeggedOdometryManager::ContactsManager::ContactsManagerSurfacesConfiguration contactsConfig(
-          observerName_, surfacesForContactDetection);
+      measurements::ContactsManagerSurfacesConfiguration contactsConfig(observerName_, surfacesForContactDetection);
       contactsConfig.contactDetectionThreshold(contactDetectionThreshold_)
           .contactSensorsDisabledInit(contactSensorsDisabledInit)
           .verbose(verbose);
@@ -119,8 +118,7 @@ void TiltObserver::configure(const mc_control::MCController & ctl, const mc_rtc:
     {
       std::vector<std::string> forceSensorsToOmit = config("forceSensorsToOmit", std::vector<std::string>());
 
-      odometry::LeggedOdometryManager::ContactsManager::ContactsManagerSensorsConfiguration contactsConfig(
-          observerName_);
+      measurements::ContactsManagerSensorsConfiguration contactsConfig(observerName_);
       contactsConfig.contactDetectionThreshold(contactDetectionThreshold_)
           .contactSensorsDisabledInit(contactSensorsDisabledInit)
           .verbose(verbose)
@@ -129,8 +127,7 @@ void TiltObserver::configure(const mc_control::MCController & ctl, const mc_rtc:
     }
     if(contactsDetectionMethod == LoContactsManager::ContactsDetection::Solver)
     {
-      odometry::LeggedOdometryManager::ContactsManager::ContactsManagerSolverConfiguration contactsConfig(
-          observerName_);
+      measurements::ContactsManagerSolverConfiguration contactsConfig(observerName_);
       contactsConfig.contactDetectionThreshold(contactDetectionThreshold_).verbose(verbose);
       odometryManager_.init(ctl, odomConfig, contactsConfig);
     }

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -48,10 +48,10 @@ void TiltObserver::configure(const mc_control::MCController & ctl, const mc_rtc:
   }
 
   std::string typeOfOdometry = static_cast<std::string>(config("odometryType"));
-
-  if(typeOfOdometry == "Flat") { odometryManager_.setOdometryType(measurements::OdometryType::Flat); }
-  else if(typeOfOdometry == "6D") { odometryManager_.setOdometryType(measurements::OdometryType::Odometry6d); }
-  else if(typeOfOdometry == "None") { odometryManager_.setOdometryType(measurements::OdometryType::None); }
+  measurements::OdometryType odometryType;
+  if(typeOfOdometry == "Flat") { odometryType = measurements::OdometryType::Flat; }
+  else if(typeOfOdometry == "6D") { odometryType = measurements::OdometryType::Odometry6d; }
+  else if(typeOfOdometry == "None") { odometryType = measurements::OdometryType::None; }
   else
   {
     mc_rtc::log::error_and_throw<std::runtime_error>("Odometry type not allowed. Please pick among : [None, Flat, 6D]");
@@ -62,8 +62,12 @@ void TiltObserver::configure(const mc_control::MCController & ctl, const mc_rtc:
     bool verbose = config("verbose", true);
     bool withYawEstimation = config("withYawEstimation", true);
 
-    odometryManager_.init(ctl, robot_, observerName_, odometryManager_.odometryType_, withYawEstimation,
-                          odometry::LeggedOdometryManager::noUpdate, verbose);
+    odometry::LeggedOdometryManager::Configuration odomConfig(robot_, observerName_, odometryType);
+    odomConfig.velocityUpdate(odometry::LeggedOdometryManager::noUpdate)
+        .withModeSwitchInGui(false)
+        .withYawEstimation(withYawEstimation);
+
+    odometryManager_.init(ctl, odomConfig, verbose);
 
     // surfaces used for the contact detection. If the desired detection method doesn't use surfaces, we make sure this
     // list is not filled in the configuration file to avoid the use of an undesired method.

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -1,6 +1,6 @@
 #include <mc_control/MCController.h>
 #include <mc_observers/ObserverMacros.h>
-#include "mc_state_observation/measurements/measurementsTools.h"
+// #include "mc_state_observation/measurements/measurementsTools.h"
 #include <mc_state_observation/TiltObserver.h>
 #include <mc_state_observation/conversions/kinematics.h>
 #include <mc_state_observation/gui_helpers.h>

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -56,7 +56,7 @@ void TiltObserver::configure(const mc_control::MCController & ctl, const mc_rtc:
   {
     mc_rtc::log::error_and_throw<std::runtime_error>("Odometry type not allowed. Please pick among : [None, Flat, 6D]");
   }
-
+  // specific configurations for the use of odometry.
   if(odometryManager_.odometryType_ != measurements::OdometryType::None)
   {
     bool verbose = config("verbose", true);

--- a/src/TiltObserver.cpp
+++ b/src/TiltObserver.cpp
@@ -18,9 +18,6 @@ TiltObserver::TiltObserver(const std::string & type, double dt, bool asBackup, c
 : mc_observers::Observer(type, dt), estimator_(alpha_, beta_, gamma_), odometryManager_(observerName)
 {
   estimator_.setSamplingTime(dt_);
-  xk_.resize(9);
-  xk_ << so::Vector3::Zero(), so::Vector3::Zero(), so::Vector3(0, 0, 1); // so::Vector3(0.49198, 0.66976, 0.55622);
-  estimator_.setState(xk_, 0);
 
   asBackup_ = asBackup;
   observerName_ = observerName;
@@ -137,16 +134,6 @@ void TiltObserver::reset(const mc_control::MCController & ctl)
   velW_ = realRobot.velW();
   prevPoseW_ = sva::PTransformd::Identity();
   velW_ = sva::MotionVecd::Zero();
-
-  so::Vector3 tilt; // not exactly the tilt but Rt * ez, corresponding to the Tilt estimator's x1
-  if(imu.linearAcceleration().norm() < 1e-4) { tilt = ctl.robot(robot_).posW().rotation() * so::Vector3::UnitZ(); }
-  else
-  {
-    tilt = imu.linearAcceleration()
-           / imu.linearAcceleration().norm(); // we consider the acceleration as zero on the initialization
-  }
-
-  estimator_.initEstimator(so::Vector3::Zero(), tilt, tilt);
 
   const Eigen::Matrix3d cOri = (imu.X_b_s() * ctl.robot(robot_).bodyPosW(imu.parentBody())).rotation();
   so::Vector3 initX2 = cOri * so::Vector3::UnitZ(); // so::kine::rotationMatrixToRotationVector(cOri.transpose());

--- a/src/odometry/LeggedOdometryManager.cpp
+++ b/src/odometry/LeggedOdometryManager.cpp
@@ -92,9 +92,13 @@ void LeggedOdometryManager::updateJointsConfiguration(const mc_control::MCContro
 
   // Copy the real configuration except for the floating base
   const auto & realQ = realRobot.mbc().q;
+  const auto & realAlpha = realRobot.mbc().alpha;
+
   std::copy(std::next(realQ.begin()), realQ.end(), std::next(odometryRobot().mbc().q.begin()));
+  std::copy(std::next(realAlpha.begin()), realAlpha.end(), std::next(odometryRobot().mbc().alpha.begin()));
 
   odometryRobot().forwardKinematics();
+  odometryRobot().forwardVelocity();
 }
 
 void LeggedOdometryManager::run(const mc_control::MCController & ctl, mc_rtc::Logger & logger, sva::PTransformd & pose)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,45 @@
+add_library(Test_Runner OBJECT test_run.cpp)
+target_link_libraries(Test_Runner PUBLIC mc_rtc::mc_control)
+
+function(TestObserver OBSERVER_NAME NR_ITER)
+  set(PIPELINE_CFG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/Test_${OBSERVER_NAME}.yaml)
+  if(NOT EXISTS ${PIPELINE_CFG_FILE})
+    message(
+      FATAL_ERROR "Missing pipeline configuration for testing ${OBSERVER_NAME}")
+  endif()
+  file(READ ${PIPELINE_CFG_FILE} OBSERVER_CFG)
+  set(CFG_CONFIGURED_OUT
+      "${CMAKE_CURRENT_BINARY_DIR}/${OBSERVER_NAME}/mc_rtc.in.yaml")
+  set(CFG_OUT
+      "${CMAKE_CURRENT_BINARY_DIR}/${OBSERVER_NAME}/$<CONFIG>/etc/mc_rtc.yaml")
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mc_rtc.in.yaml"
+                 "${CFG_CONFIGURED_OUT}" @ONLY)
+  file(
+    GENERATE
+    OUTPUT ${CFG_OUT}
+    INPUT ${CFG_CONFIGURED_OUT})
+  set(CPP_CONFIGURED_OUT
+      "${CMAKE_CURRENT_BINARY_DIR}/${OBSERVER_NAME}/config.in.cpp")
+  set(CPP_OUT
+      "${CMAKE_CURRENT_BINARY_DIR}/${OBSERVER_NAME}/$<CONFIG>/config.cpp")
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.in.cpp
+                 ${CPP_CONFIGURED_OUT} @ONLY)
+  file(
+    GENERATE
+    OUTPUT ${CPP_OUT}
+    INPUT ${CPP_CONFIGURED_OUT})
+  add_executable(Test_${OBSERVER_NAME} ${CPP_OUT})
+  target_link_libraries(Test_${OBSERVER_NAME} PUBLIC Test_Runner)
+  add_test(NAME Test_${OBSERVER_NAME} COMMAND Test_${OBSERVER_NAME})
+endfunction()
+
+testobserver(Attitude 100)
+testobserver(MCKineticsObserver 100)
+testobserver(NaiveOdometry 100)
+testobserver(Tilt 100)
+
+if(WITH_ROS_OBSERVERS)
+  testobserver(MocapObserverROS 100)
+  testobserver(SLAM 100)
+  testobserver(Object 100)
+endif()

--- a/tests/Test_Attitude.yaml
+++ b/tests/Test_Attitude.yaml
@@ -1,0 +1,10 @@
+ObserverModulePaths: ["$<TARGET_FILE_DIR:AttitudeObserver>"]
+ObserverPipelines:
+  name: MainObserverPipeline
+  gui: false
+  observers:
+    - type: Attitude
+      update: true
+      config:
+        KalmanFilter:
+          gyr_cov: 1e-6

--- a/tests/Test_MCKineticsObserver.yaml
+++ b/tests/Test_MCKineticsObserver.yaml
@@ -1,0 +1,78 @@
+ObserverModulePaths: ["$<TARGET_FILE_DIR:TiltObserver>"]
+ObserverPipelines:
+  name: MainObserverPipeline
+  gui: false
+  observers:
+    - type: Tilt
+      update: true
+      config:
+        asBackup: true
+        odometryType: Flat
+        velUpdatedUpstream: false
+        accUpdatedUpstream: false
+        contactsDetection: Surfaces
+        surfacesForContactDetection: [RightFootCenter, LeftFootCenter]
+    - type: MCKineticsObserver
+      update: true
+      config:
+        odometryType: Flat
+        contactsDetection: Surfaces
+        surfacesForContactDetection: [RightFootCenter, LeftFootCenter]
+
+        withDebugLogs: true
+        withFiniteDifferences: false
+        finiteDifferenceStep: 1e-6
+        withGyroBias: true
+        withUnmodeledWrench: false
+        contactDetectionPropThreshold: 0.110
+
+        withFilteredForcesContactDetection: false
+        withAccelerationEstimation: true
+        withRungeKutta: false
+
+        contactsSensorDisabledInit: []
+
+        statePositionInitVariance: [0.0, 0.0, 0.0]
+        stateOriInitVariance: [0.0, 0.0, 0.0]
+        stateLinVelInitVariance: [0.0, 0.0, 0.0]
+        stateAngVelInitVariance: [0.0, 0.0, 0.0]
+        gyroBiasInitVariance: [1e-8, 1e-8, 1e-8]
+        unmodeledForceInitVariance: [0, 0, 0]
+        unmodeledTorqueInitVariance: [0.0, 0.0, 0.0]
+
+        contactPositionInitVarianceFirstContacts: [0.0, 0.0, 0.0]
+        contactOriInitVarianceFirstContacts: [0.0, 0.0, 0.0]
+        contactForceInitVarianceFirstContacts: [400, 400, 400]
+        contactTorqueInitVarianceFirstContacts: [36e1, 36e1, 36e1]
+
+        contactPositionInitVarianceNewContacts: [1e-9, 1e-8, 1e-8]
+        contactOriInitVarianceNewContacts: [1e-6, 1e-6, 1e-6]
+        contactForceInitVarianceNewContacts: [400, 400, 400]
+        contactTorqueInitVarianceNewContacts: [36e1, 36e1, 36e1]
+
+        statePositionProcessVariance: [1e-10, 1e-10, 1e-10]
+        stateOriProcessVariance: [1e-12, 1e-12, 1e-12]
+        stateLinVelProcessVariance: [0.0, 0.0, 0.0]
+        stateAngVelProcessVariance: [0.0, 0.0, 0.0]
+        gyroBiasProcessVariance: [1e-12, 1e-12, 1e-12]
+        unmodeledForceProcessVariance: [9e-2, 9e-2, 9e-2]
+        unmodeledTorqueProcessVariance: [5e-2, 5e-2, 5e-2]
+        contactPositionProcessVariance: [0.0, 0.0, 0.0]
+        contactOrientationProcessVariance: [0.0, 0.0, 0.0]
+        contactForceProcessVariance: [250, 250, 2.5e2]
+        contactTorqueProcessVariance: [25e1, 25e1, 25e1]
+
+        acceleroSensorVariance: [1e-4, 1e-4, 1e-4]
+        gyroSensorVariance: [1e-6, 1e-6, 1e-6]
+        forceSensorVariance: [2e1, 2e1, 2e1]
+        torqueSensorVariance: [1.5e0, 1.5e0, 1.5e0]
+
+        positionSensorVariance: [0.0, 0.0, 0.0]
+        orientationSensorVariance: [0.0, 0.0, 0.0]
+
+        linStiffness: [1.0, 1.0, 1.0]
+        angStiffness: [1.0, 1.0, 1.0]
+        linDamping: [1.0, 1.0, 1.0]
+        angDamping: [1.0, 1.0, 1.0]
+
+        absOriSensorVariance: [0.0, 0.0, 0.0]

--- a/tests/Test_MocapObserverROS.yaml
+++ b/tests/Test_MocapObserverROS.yaml
@@ -1,0 +1,7 @@
+ObserverModulePaths: ["$<TARGET_FILE_DIR:MocapObserverROS>"]
+ObserverPipelines:
+  name: MainObserverPipeline
+  gui: false
+  observers:
+    - type: MocapObserverROS
+      update: false

--- a/tests/Test_NaiveOdometry.yaml
+++ b/tests/Test_NaiveOdometry.yaml
@@ -1,0 +1,13 @@
+ObserverModulePaths: ["$<TARGET_FILE_DIR:TiltObserver>"]
+ObserverPipelines:
+  name: MainObserverPipeline
+  gui: false
+  observers:
+    - type: NaiveOdometry
+      update: true
+      config:
+        odometryType: 6D
+        velUpdatedUpstream: false
+        accUpdatedUpstream: false
+        contactsDetection: Surfaces
+        surfacesForContactDetection: [RightFootCenter, LeftFootCenter]

--- a/tests/Test_Object.yaml
+++ b/tests/Test_Object.yaml
@@ -1,0 +1,14 @@
+ObserverModulePaths: ["$<TARGET_FILE_DIR:SLAMObserver>"]
+ObserverPipelines:
+  name: MainObserverPipeline
+  gui: false
+  observers:
+    - type: Object
+      update: false
+      config:
+        Robot:
+          jvrc1:
+            camera: NECK_P_S
+        Object:
+          robot: ground
+          topic: /not/relevant

--- a/tests/Test_SLAM.yaml
+++ b/tests/Test_SLAM.yaml
@@ -1,0 +1,14 @@
+ObserverModulePaths: ["$<TARGET_FILE_DIR:SLAMObserver>"]
+ObserverPipelines:
+  name: MainObserverPipeline
+  gui: false
+  observers:
+    - type: SLAM
+      update: false
+      config:
+        Robot:
+          jvrc1:
+            camera: NECK_P_S
+        SLAM:
+          map: odom
+          estimated: camera_frame

--- a/tests/Test_Tilt.yaml
+++ b/tests/Test_Tilt.yaml
@@ -1,0 +1,13 @@
+ObserverModulePaths: ["$<TARGET_FILE_DIR:TiltObserver>"]
+ObserverPipelines:
+  name: MainObserverPipeline
+  gui: false
+  observers:
+    - type: Tilt
+      update: true
+      config:
+        odometryType: Flat
+        velUpdatedUpstream: false
+        accUpdatedUpstream: false
+        contactsDetection: Surfaces
+        surfacesForContactDetection: [RightFootCenter, LeftFootCenter]

--- a/tests/config.in.cpp
+++ b/tests/config.in.cpp
@@ -1,0 +1,18 @@
+#include <string>
+
+namespace mc_state_observation
+{
+
+std::string get_test_configuration()
+{
+  return "@CFG_OUT@";
+}
+
+size_t nrIter()
+{
+  // clang-format off
+  return @NR_ITER@;
+  // clang-format on
+}
+
+} // namespace mc_state_observation

--- a/tests/mc_rtc.in.yaml
+++ b/tests/mc_rtc.in.yaml
@@ -1,0 +1,8 @@
+MainRobot: JVRC1
+Enabled: Posture
+Timestep: 0.005
+Log: false
+GUIServer:
+  Enable: false
+ClearObserverModulePath: true
+@OBSERVER_CFG@

--- a/tests/test_run.cpp
+++ b/tests/test_run.cpp
@@ -1,0 +1,27 @@
+#include <mc_control/Ticker.h>
+
+namespace mc_state_observation
+{
+
+std::string get_test_configuration();
+
+size_t nrIter();
+
+} // namespace mc_state_observation
+
+int main()
+{
+  mc_control::Ticker::Configuration config;
+  config.mc_rtc_configuration = mc_state_observation::get_test_configuration();
+  mc_control::Ticker ticker(config);
+  for(size_t i = 0; i < mc_state_observation::nrIter(); ++i)
+  {
+    bool r = ticker.step();
+    if(!r)
+    {
+      mc_rtc::log::critical("Failed at iter {}", i);
+      return 1;
+    }
+  }
+  return 0;
+}


### PR DESCRIPTION
The KineticsObserver is an MEKF-based (Mulitplicative Extended Kalman Filter) estimator that relies on a visco-elastic model of contacts to estimate the following variables: the pose of the robot in the world, its velocity, the external wrench applied on the centroid, the bias on the gyrometer bias, and the contact wrenches and pose.

The TiltObserver is based on a complementary filter which estimates the tilt and the local velocity of the IMU.

Also adding LeggedOdometry, that can be called after updating the realRobot with another estimator. It uses the estimated tilt to perform an odometry based on the successive contacts, giving a pose in the world. This method assumes that contacts are subject to no slippage.

Both observers can perform either:
- no odometry: the estimated robot remains attached to the control robot.
- flat odometry: the TiltObserver will perform a legged odometry using its estimation of the tilt of the robot. The Kinetics Observer will use its visco-elastic model to correct the contacts pose and is therefore more robust to slippage. This odometry mode will consider that the contacts are always on a height z = 0m, which allows a more accurate estimation on flat grounds.
- 6d odometry: The height constraint for the contacts is not applied here so the odometry can be performed on non-flat environments.

